### PR TITLE
[#9] 회원 서비스 유닛 테스트에 모킹 적용

### DIFF
--- a/src/test/java/com/flab/funding/service/MemberDeliveryAddressServiceTest.java
+++ b/src/test/java/com/flab/funding/service/MemberDeliveryAddressServiceTest.java
@@ -1,59 +1,52 @@
 package com.flab.funding.service;
 
+import com.flab.funding.application.ports.output.MemberDeliveryAddressPort;
+import com.flab.funding.application.ports.output.MemberPort;
 import com.flab.funding.domain.model.DeliveryAddress;
 import com.flab.funding.domain.model.Member;
 import com.flab.funding.domain.model.MemberGender;
 import com.flab.funding.domain.model.MemberLinkType;
 import com.flab.funding.domain.service.MemberDeliveryAddressService;
-import com.flab.funding.domain.service.MemberService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
+import org.mapstruct.Named;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest
-@Transactional
+@ExtendWith({MockitoExtension.class})
 public class MemberDeliveryAddressServiceTest {
 
-    @Autowired
+    @InjectMocks
     private MemberDeliveryAddressService memberDeliveryAddressService;
 
-    @Autowired
-    private MemberService memberService;
+    @Mock
+    private MemberDeliveryAddressPort memberDeliveryAddressPort;
 
-    private String userKey;
-
-    @BeforeEach
-    void setUp() {
-        Member savedMember = memberService.registerMember(getMember());
-        userKey = savedMember.getUserKey();
-    }
-
-    private Member getMember() {
-        return Member.builder()
-                .linkType(MemberLinkType.NONE)
-                .email("DeliveryAddress@gmail.com")
-                .userName("홍길순")
-                .nickName("테스터")
-                .phoneNumber("010-1111-2222")
-                .gender(MemberGender.FEMALE)
-                .birthday(LocalDate.of(1998, 1, 30))
-                .password("")
-                .build();
-    }
+    @Mock
+    private MemberPort memberPort;
 
     @Test
-    public void 배송지_등록() throws Exception {
+    @Named("배송지 등록")
+    public void registerDeliveryAddress() {
         //given
         DeliveryAddress deliveryAddress = getDeliveryAddress();
+
+        given(memberPort.getMemberByUserKey(eq(deliveryAddress.getMember().getUserKey())))
+                .willReturn(getMember());
+
+        given(memberDeliveryAddressPort.saveDeliveryAddress(any(DeliveryAddress.class)))
+                .willReturn(deliveryAddress.register(getMember()));
+
+        given(memberDeliveryAddressPort.getDeliveryAddressByDeliveryAddressKey(any()))
+                .willReturn(deliveryAddress);
 
         //when
         DeliveryAddress savedDeliveryAddress =
@@ -78,7 +71,7 @@ public class MemberDeliveryAddressServiceTest {
     private DeliveryAddress getDeliveryAddress() {
 
         return DeliveryAddress.builder()
-                .member(getSavedMember())
+                .member(getMember())
                 .isDefault(true)
                 .zipCode("01234")
                 .address("서울특별시 강서구")
@@ -88,7 +81,17 @@ public class MemberDeliveryAddressServiceTest {
                 .build();
     }
 
-    private Member getSavedMember() {
-        return Member.builder().userKey(userKey).build();
+    private Member getMember() {
+        return Member.builder()
+                .userKey("MM-0001")
+                .linkType(MemberLinkType.NONE)
+                .email("DeliveryAddress@gmail.com")
+                .userName("홍길순")
+                .nickName("테스터")
+                .phoneNumber("010-1111-2222")
+                .gender(MemberGender.FEMALE)
+                .birthday(LocalDate.of(1998, 1, 30))
+                .password("")
+                .build();
     }
 }

--- a/src/test/java/com/flab/funding/service/MemberDeliveryAddressServiceTest.java
+++ b/src/test/java/com/flab/funding/service/MemberDeliveryAddressServiceTest.java
@@ -43,7 +43,7 @@ public class MemberDeliveryAddressServiceTest {
                 .willReturn(getMember());
 
         given(memberDeliveryAddressPort.saveDeliveryAddress(any(DeliveryAddress.class)))
-                .willReturn(deliveryAddress.register(getMember()));
+                .willReturn(deliveryAddress);
 
         given(memberDeliveryAddressPort.getDeliveryAddressByDeliveryAddressKey(any()))
                 .willReturn(deliveryAddress);

--- a/src/test/java/com/flab/funding/service/MemberPaymentMethodServiceTest.java
+++ b/src/test/java/com/flab/funding/service/MemberPaymentMethodServiceTest.java
@@ -43,7 +43,7 @@ public class MemberPaymentMethodServiceTest {
                 .willReturn(getMember());
 
         given(memberPaymentMethodPort.savePaymentMethod(any(PaymentMethod.class)))
-                .willReturn(paymentMethod.register(getMember()));
+                .willReturn(paymentMethod);
 
         given(memberPaymentMethodPort.getPaymentMethodByPaymentMethodKey(any()))
                 .willReturn(paymentMethod);

--- a/src/test/java/com/flab/funding/service/MemberPaymentMethodServiceTest.java
+++ b/src/test/java/com/flab/funding/service/MemberPaymentMethodServiceTest.java
@@ -1,59 +1,52 @@
 package com.flab.funding.service;
 
+import com.flab.funding.application.ports.output.MemberPaymentMethodPort;
+import com.flab.funding.application.ports.output.MemberPort;
 import com.flab.funding.domain.model.Member;
 import com.flab.funding.domain.model.MemberGender;
 import com.flab.funding.domain.model.MemberLinkType;
 import com.flab.funding.domain.model.PaymentMethod;
 import com.flab.funding.domain.service.MemberPaymentMethodService;
-import com.flab.funding.domain.service.MemberService;
-import org.junit.jupiter.api.BeforeEach;
+import jdk.jfr.Name;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest
-@Transactional
+@ExtendWith({MockitoExtension.class})
 public class MemberPaymentMethodServiceTest {
 
-    @Autowired
+    @InjectMocks
     private MemberPaymentMethodService memberPaymentMethodService;
 
-    @Autowired
-    private MemberService memberService;
+    @Mock
+    private MemberPaymentMethodPort memberPaymentMethodPort;
 
-    private String userKey;
-
-    @BeforeEach
-    void setUp() {
-        Member savedMember = memberService.registerMember(getMember());
-        userKey = savedMember.getUserKey();
-    }
-
-    private Member getMember() {
-        return Member.builder()
-                .linkType(MemberLinkType.NONE)
-                .email("Test@gmail.com")
-                .userName("홍길순")
-                .nickName("테스터")
-                .phoneNumber("010-1111-2222")
-                .gender(MemberGender.FEMALE)
-                .birthday(LocalDate.of(1998, 1, 30))
-                .password("")
-                .build();
-    }
+    @Mock
+    private MemberPort memberPort;
 
     @Test
-    public void 결제수단_등록() throws Exception {
+    @Name("결제수단 등록")
+    public void registerPaymentMethod() {
         //given
         PaymentMethod paymentMethod = getPaymentMethod();
+
+        given(memberPort.getMemberByUserKey(eq(paymentMethod.getMember().getUserKey())))
+                .willReturn(getMember());
+
+        given(memberPaymentMethodPort.savePaymentMethod(any(PaymentMethod.class)))
+                .willReturn(paymentMethod.register(getMember()));
+
+        given(memberPaymentMethodPort.getPaymentMethodByPaymentMethodKey(any()))
+                .willReturn(paymentMethod);
 
         //when
         PaymentMethod savedPaymentMethod = memberPaymentMethodService.registerPaymentMethod(paymentMethod);
@@ -70,13 +63,23 @@ public class MemberPaymentMethodServiceTest {
 
     private PaymentMethod getPaymentMethod() {
         return PaymentMethod.builder()
-                .member(getSavedMember())
+                .member(getMember())
                 .isDefault(true)
                 .paymentNumber("3565 43")
                 .build();
     }
 
-    private Member getSavedMember() {
-        return Member.builder().userKey(userKey).build();
+    private Member getMember() {
+        return Member.builder()
+                .userKey("MM-0001")
+                .linkType(MemberLinkType.NONE)
+                .email("Test@gmail.com")
+                .userName("홍길순")
+                .nickName("테스터")
+                .phoneNumber("010-1111-2222")
+                .gender(MemberGender.FEMALE)
+                .birthday(LocalDate.of(1998, 1, 30))
+                .password("")
+                .build();
     }
 }

--- a/src/test/java/com/flab/funding/service/MemberServiceTest.java
+++ b/src/test/java/com/flab/funding/service/MemberServiceTest.java
@@ -37,7 +37,7 @@ public class MemberServiceTest {
         //given
         Member member = getMember();
 
-        given(memberPort.saveMember(any(member.getClass())))
+        given(memberPort.saveMember(any(Member.class)))
                 .willReturn(member);
 
         given(memberPort.getMemberByEmail(member.getEmail()))
@@ -51,7 +51,6 @@ public class MemberServiceTest {
         Member findMember = memberService.getMemberByUserKey(savedMember.getUserKey());
 
         //then
-        assertEquals(savedMember.getId(), findMember.getId());
         assertEquals(savedMember.getId(), findMember.getId());
         assertEquals(savedMember.getUserKey(), findMember.getUserKey());
         assertEquals(savedMember.getLinkType(), findMember.getLinkType());
@@ -100,7 +99,7 @@ public class MemberServiceTest {
         given(memberPort.getMemberByUserKey(any()))
                 .willReturn(member);
 
-        given(memberPort.saveMember(any(member.getClass())))
+        given(memberPort.saveMember(any(Member.class)))
                 .willReturn(member);
 
         //when

--- a/src/test/java/com/flab/funding/service/MemberServiceTest.java
+++ b/src/test/java/com/flab/funding/service/MemberServiceTest.java
@@ -9,6 +9,7 @@ import com.flab.funding.domain.model.MemberStatus;
 import com.flab.funding.domain.service.MemberService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.Named;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -31,7 +32,8 @@ public class MemberServiceTest {
     private MemberPort memberPort;
 
     @Test
-    public void 회원가입() throws Exception {
+    @Named("회원가입")
+    public void join() {
         //given
         Member member = getMember();
 
@@ -76,7 +78,8 @@ public class MemberServiceTest {
     }
 
     @Test
-    public void 중복_회원_예외() throws Exception {
+    @Named("중복 회원 예외")
+    public void duplicateMember() {
         //given
         Member member = getMember();
 
@@ -89,7 +92,8 @@ public class MemberServiceTest {
     }
 
     @Test
-    public void 회원탈퇴() throws Exception {
+    @Named("회원탈퇴")
+    public void withdraw() {
         //given
         Member member = getMember();
 


### PR DESCRIPTION
### 작업내역
- 회원 관련 서비스 테스트에 모킹 적용
- 서비스 목록: 회원, 배송지, 결제수단 서비스