### PR TITLE
[#13] 도메인 모델 정리

### DIFF
--- a/src/main/generated/com/flab/funding/infrastructure/adapters/input/mapper/SupportMapperImpl.java
+++ b/src/main/generated/com/flab/funding/infrastructure/adapters/input/mapper/SupportMapperImpl.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-17T20:12:32+0900",
+    date = "2024-03-25T18:49:59+0900",
     comments = "version: 1.5.5.Final, compiler: javac, environment: Java 17.0.9 (Oracle Corporation)"
 )
 @Component
@@ -27,7 +27,6 @@ public class SupportMapperImpl implements SupportMapper {
 
         Support.SupportBuilder support = Support.builder();
 
-        support.rewardId( supportRegisterRequest.getRewardId() );
         support.supportDelivery( supportDeliveryRequestToSupportDelivery( supportRegisterRequest.getSupportDelivery() ) );
         support.supportPayment( supportPaymentRequestToSupportPayment( supportRegisterRequest.getSupportPayment() ) );
 
@@ -56,7 +55,6 @@ public class SupportMapperImpl implements SupportMapper {
 
         SupportDeliveryInfoResponse.SupportDeliveryInfoResponseBuilder supportDeliveryInfoResponse = SupportDeliveryInfoResponse.builder();
 
-        supportDeliveryInfoResponse.supportKey( supportDelivery.getSupportKey() );
         supportDeliveryInfoResponse.status( supportDelivery.getStatus() );
 
         return supportDeliveryInfoResponse.build();

--- a/src/main/generated/com/flab/funding/infrastructure/adapters/output/persistence/mapper/FundingPersistenceMapperImpl.java
+++ b/src/main/generated/com/flab/funding/infrastructure/adapters/output/persistence/mapper/FundingPersistenceMapperImpl.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-17T20:12:32+0900",
+    date = "2024-03-24T20:52:31+0900",
     comments = "version: 1.5.5.Final, compiler: javac, environment: Java 17.0.9 (Oracle Corporation)"
 )
 @Component
@@ -105,8 +105,8 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
 
         FundingCreatorEntity.FundingCreatorEntityBuilder fundingCreatorEntity = FundingCreatorEntity.builder();
 
-        fundingCreatorEntity.funding( fundingCreatorToFundingEntity( fundingCreator ) );
         fundingCreatorEntity.id( fundingCreator.getId() );
+        fundingCreatorEntity.funding( toFundingEntity( fundingCreator.getFunding() ) );
         fundingCreatorEntity.isValid( fundingCreator.getIsValid() );
         fundingCreatorEntity.businessNumber( fundingCreator.getBusinessNumber() );
         fundingCreatorEntity.representative( fundingCreator.getRepresentative() );
@@ -125,9 +125,8 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
 
         FundingCreator.FundingCreatorBuilder fundingCreator = FundingCreator.builder();
 
-        fundingCreator.fundingId( fundingCreatorEntityFundingId( fundingCreatorEntity ) );
-        fundingCreator.fundingKey( fundingCreatorEntityFundingFundingKey( fundingCreatorEntity ) );
         fundingCreator.id( fundingCreatorEntity.getId() );
+        fundingCreator.funding( toFunding( fundingCreatorEntity.getFunding() ) );
         fundingCreator.isValid( fundingCreatorEntity.getIsValid() );
         fundingCreator.businessNumber( fundingCreatorEntity.getBusinessNumber() );
         fundingCreator.representative( fundingCreatorEntity.getRepresentative() );
@@ -146,8 +145,8 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
 
         FundingItemEntity.FundingItemEntityBuilder fundingItemEntity = FundingItemEntity.builder();
 
-        fundingItemEntity.funding( fundingItemToFundingEntity( fundingItem ) );
         fundingItemEntity.id( fundingItem.getId() );
+        fundingItemEntity.funding( toFundingEntity( fundingItem.getFunding() ) );
         fundingItemEntity.itemName( fundingItem.getItemName() );
         fundingItemEntity.optionType( fundingItem.getOptionType() );
         fundingItemEntity.fundingItemOptions( fundingItemOptionListToFundingItemOptionEntityList( fundingItem.getFundingItemOptions() ) );
@@ -165,9 +164,8 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
 
         FundingItem.FundingItemBuilder fundingItem = FundingItem.builder();
 
-        fundingItem.fundingId( fundingItemEntityFundingId( fundingItemEntity ) );
-        fundingItem.fundingKey( fundingItemEntityFundingFundingKey( fundingItemEntity ) );
         fundingItem.id( fundingItemEntity.getId() );
+        fundingItem.funding( toFunding( fundingItemEntity.getFunding() ) );
         fundingItem.itemName( fundingItemEntity.getItemName() );
         fundingItem.optionType( fundingItemEntity.getOptionType() );
         fundingItem.fundingItemOptions( fundingItemOptionEntityListToFundingItemOptionList( fundingItemEntity.getFundingItemOptions() ) );
@@ -185,8 +183,8 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
 
         FundingRewardEntity.FundingRewardEntityBuilder fundingRewardEntity = FundingRewardEntity.builder();
 
-        fundingRewardEntity.funding( fundingRewardToFundingEntity( fundingReward ) );
         fundingRewardEntity.id( fundingReward.getId() );
+        fundingRewardEntity.funding( toFundingEntity( fundingReward.getFunding() ) );
         fundingRewardEntity.isDelivery( fundingReward.getIsDelivery() );
         fundingRewardEntity.rewardTitle( fundingReward.getRewardTitle() );
         fundingRewardEntity.amount( fundingReward.getAmount() );
@@ -208,9 +206,8 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
 
         FundingReward.FundingRewardBuilder fundingReward = FundingReward.builder();
 
-        fundingReward.fundingId( fundingRewardEntityFundingId( fundingRewardEntity ) );
-        fundingReward.fundingKey( fundingRewardEntityFundingFundingKey( fundingRewardEntity ) );
         fundingReward.id( fundingRewardEntity.getId() );
+        fundingReward.funding( toFunding( fundingRewardEntity.getFunding() ) );
         fundingReward.isDelivery( fundingRewardEntity.getIsDelivery() );
         fundingReward.rewardTitle( fundingRewardEntity.getRewardTitle() );
         fundingReward.amount( fundingRewardEntity.getAmount() );
@@ -232,10 +229,10 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
 
         FundingRewardItemEntity.FundingRewardItemEntityBuilder fundingRewardItemEntity = FundingRewardItemEntity.builder();
 
-        fundingRewardItemEntity.funding( fundingRewardItemToFundingEntity( fundingRewardItem ) );
-        fundingRewardItemEntity.fundingReward( fundingRewardItemToFundingRewardEntity( fundingRewardItem ) );
-        fundingRewardItemEntity.fundingItem( fundingRewardItemToFundingItemEntity( fundingRewardItem ) );
         fundingRewardItemEntity.id( fundingRewardItem.getId() );
+        fundingRewardItemEntity.funding( toFundingEntity( fundingRewardItem.getFunding() ) );
+        fundingRewardItemEntity.fundingReward( toFundingRewardEntity( fundingRewardItem.getFundingReward() ) );
+        fundingRewardItemEntity.fundingItem( toFundingItemEntity( fundingRewardItem.getFundingItem() ) );
         fundingRewardItemEntity.createdAt( fundingRewardItem.getCreatedAt() );
         fundingRewardItemEntity.updatedAt( fundingRewardItem.getUpdatedAt() );
 
@@ -250,10 +247,10 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
 
         FundingRewardItem.FundingRewardItemBuilder fundingRewardItem = FundingRewardItem.builder();
 
-        fundingRewardItem.fundingId( fundingRewardItemEntityFundingId( fundingRewardItemEntity ) );
-        fundingRewardItem.fundingRewardId( fundingRewardItemEntityFundingRewardId( fundingRewardItemEntity ) );
-        fundingRewardItem.fundingItemId( fundingRewardItemEntityFundingItemId( fundingRewardItemEntity ) );
         fundingRewardItem.id( fundingRewardItemEntity.getId() );
+        fundingRewardItem.funding( toFunding( fundingRewardItemEntity.getFunding() ) );
+        fundingRewardItem.fundingReward( toFundingReward( fundingRewardItemEntity.getFundingReward() ) );
+        fundingRewardItem.fundingItem( toFundingItem( fundingRewardItemEntity.getFundingItem() ) );
         fundingRewardItem.createdAt( fundingRewardItemEntity.getCreatedAt() );
         fundingRewardItem.updatedAt( fundingRewardItemEntity.getUpdatedAt() );
 
@@ -293,6 +290,7 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
         FundingTagEntity.FundingTagEntityBuilder fundingTagEntity = FundingTagEntity.builder();
 
         fundingTagEntity.id( fundingTag.getId() );
+        fundingTagEntity.funding( toFundingEntity( fundingTag.getFunding() ) );
         fundingTagEntity.tag( fundingTag.getTag() );
         fundingTagEntity.createdAt( fundingTag.getCreatedAt() );
         fundingTagEntity.updatedAt( fundingTag.getUpdatedAt() );
@@ -346,6 +344,7 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
         FundingTag.FundingTagBuilder fundingTag = FundingTag.builder();
 
         fundingTag.id( fundingTagEntity.getId() );
+        fundingTag.funding( toFunding( fundingTagEntity.getFunding() ) );
         fundingTag.tag( fundingTagEntity.getTag() );
         fundingTag.createdAt( fundingTagEntity.getCreatedAt() );
         fundingTag.updatedAt( fundingTagEntity.getUpdatedAt() );
@@ -366,61 +365,6 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
         return list1;
     }
 
-    protected FundingEntity fundingCreatorToFundingEntity(FundingCreator fundingCreator) {
-        if ( fundingCreator == null ) {
-            return null;
-        }
-
-        FundingEntity.FundingEntityBuilder fundingEntity = FundingEntity.builder();
-
-        fundingEntity.fundingKey( fundingCreator.getFundingKey() );
-
-        return fundingEntity.build();
-    }
-
-    private Long fundingCreatorEntityFundingId(FundingCreatorEntity fundingCreatorEntity) {
-        if ( fundingCreatorEntity == null ) {
-            return null;
-        }
-        FundingEntity funding = fundingCreatorEntity.getFunding();
-        if ( funding == null ) {
-            return null;
-        }
-        Long id = funding.getId();
-        if ( id == null ) {
-            return null;
-        }
-        return id;
-    }
-
-    private String fundingCreatorEntityFundingFundingKey(FundingCreatorEntity fundingCreatorEntity) {
-        if ( fundingCreatorEntity == null ) {
-            return null;
-        }
-        FundingEntity funding = fundingCreatorEntity.getFunding();
-        if ( funding == null ) {
-            return null;
-        }
-        String fundingKey = funding.getFundingKey();
-        if ( fundingKey == null ) {
-            return null;
-        }
-        return fundingKey;
-    }
-
-    protected FundingEntity fundingItemToFundingEntity(FundingItem fundingItem) {
-        if ( fundingItem == null ) {
-            return null;
-        }
-
-        FundingEntity.FundingEntityBuilder fundingEntity = FundingEntity.builder();
-
-        fundingEntity.id( fundingItem.getFundingId() );
-        fundingEntity.fundingKey( fundingItem.getFundingKey() );
-
-        return fundingEntity.build();
-    }
-
     protected FundingItemOptionEntity fundingItemOptionToFundingItemOptionEntity(FundingItemOption fundingItemOption) {
         if ( fundingItemOption == null ) {
             return null;
@@ -429,6 +373,7 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
         FundingItemOptionEntity.FundingItemOptionEntityBuilder fundingItemOptionEntity = FundingItemOptionEntity.builder();
 
         fundingItemOptionEntity.id( fundingItemOption.getId() );
+        fundingItemOptionEntity.fundingItem( toFundingItemEntity( fundingItemOption.getFundingItem() ) );
         fundingItemOptionEntity.createdAt( fundingItemOption.getCreatedAt() );
         fundingItemOptionEntity.updatedAt( fundingItemOption.getUpdatedAt() );
 
@@ -448,36 +393,6 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
         return list1;
     }
 
-    private Long fundingItemEntityFundingId(FundingItemEntity fundingItemEntity) {
-        if ( fundingItemEntity == null ) {
-            return null;
-        }
-        FundingEntity funding = fundingItemEntity.getFunding();
-        if ( funding == null ) {
-            return null;
-        }
-        Long id = funding.getId();
-        if ( id == null ) {
-            return null;
-        }
-        return id;
-    }
-
-    private String fundingItemEntityFundingFundingKey(FundingItemEntity fundingItemEntity) {
-        if ( fundingItemEntity == null ) {
-            return null;
-        }
-        FundingEntity funding = fundingItemEntity.getFunding();
-        if ( funding == null ) {
-            return null;
-        }
-        String fundingKey = funding.getFundingKey();
-        if ( fundingKey == null ) {
-            return null;
-        }
-        return fundingKey;
-    }
-
     protected FundingItemOption fundingItemOptionEntityToFundingItemOption(FundingItemOptionEntity fundingItemOptionEntity) {
         if ( fundingItemOptionEntity == null ) {
             return null;
@@ -486,6 +401,7 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
         FundingItemOption.FundingItemOptionBuilder fundingItemOption = FundingItemOption.builder();
 
         fundingItemOption.id( fundingItemOptionEntity.getId() );
+        fundingItemOption.fundingItem( toFundingItem( fundingItemOptionEntity.getFundingItem() ) );
         fundingItemOption.createdAt( fundingItemOptionEntity.getCreatedAt() );
         fundingItemOption.updatedAt( fundingItemOptionEntity.getUpdatedAt() );
 
@@ -505,19 +421,6 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
         return list1;
     }
 
-    protected FundingEntity fundingRewardToFundingEntity(FundingReward fundingReward) {
-        if ( fundingReward == null ) {
-            return null;
-        }
-
-        FundingEntity.FundingEntityBuilder fundingEntity = FundingEntity.builder();
-
-        fundingEntity.id( fundingReward.getFundingId() );
-        fundingEntity.fundingKey( fundingReward.getFundingKey() );
-
-        return fundingEntity.build();
-    }
-
     protected List<FundingRewardItemEntity> fundingRewardItemListToFundingRewardItemEntityList(List<FundingRewardItem> list) {
         if ( list == null ) {
             return null;
@@ -531,36 +434,6 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
         return list1;
     }
 
-    private Long fundingRewardEntityFundingId(FundingRewardEntity fundingRewardEntity) {
-        if ( fundingRewardEntity == null ) {
-            return null;
-        }
-        FundingEntity funding = fundingRewardEntity.getFunding();
-        if ( funding == null ) {
-            return null;
-        }
-        Long id = funding.getId();
-        if ( id == null ) {
-            return null;
-        }
-        return id;
-    }
-
-    private String fundingRewardEntityFundingFundingKey(FundingRewardEntity fundingRewardEntity) {
-        if ( fundingRewardEntity == null ) {
-            return null;
-        }
-        FundingEntity funding = fundingRewardEntity.getFunding();
-        if ( funding == null ) {
-            return null;
-        }
-        String fundingKey = funding.getFundingKey();
-        if ( fundingKey == null ) {
-            return null;
-        }
-        return fundingKey;
-    }
-
     protected List<FundingRewardItem> fundingRewardItemEntityListToFundingRewardItemList(List<FundingRewardItemEntity> list) {
         if ( list == null ) {
             return null;
@@ -572,86 +445,5 @@ public class FundingPersistenceMapperImpl implements FundingPersistenceMapper {
         }
 
         return list1;
-    }
-
-    protected FundingEntity fundingRewardItemToFundingEntity(FundingRewardItem fundingRewardItem) {
-        if ( fundingRewardItem == null ) {
-            return null;
-        }
-
-        FundingEntity.FundingEntityBuilder fundingEntity = FundingEntity.builder();
-
-        fundingEntity.id( fundingRewardItem.getFundingId() );
-
-        return fundingEntity.build();
-    }
-
-    protected FundingRewardEntity fundingRewardItemToFundingRewardEntity(FundingRewardItem fundingRewardItem) {
-        if ( fundingRewardItem == null ) {
-            return null;
-        }
-
-        FundingRewardEntity.FundingRewardEntityBuilder fundingRewardEntity = FundingRewardEntity.builder();
-
-        fundingRewardEntity.id( fundingRewardItem.getFundingRewardId() );
-
-        return fundingRewardEntity.build();
-    }
-
-    protected FundingItemEntity fundingRewardItemToFundingItemEntity(FundingRewardItem fundingRewardItem) {
-        if ( fundingRewardItem == null ) {
-            return null;
-        }
-
-        FundingItemEntity.FundingItemEntityBuilder fundingItemEntity = FundingItemEntity.builder();
-
-        fundingItemEntity.id( fundingRewardItem.getFundingItemId() );
-
-        return fundingItemEntity.build();
-    }
-
-    private Long fundingRewardItemEntityFundingId(FundingRewardItemEntity fundingRewardItemEntity) {
-        if ( fundingRewardItemEntity == null ) {
-            return null;
-        }
-        FundingEntity funding = fundingRewardItemEntity.getFunding();
-        if ( funding == null ) {
-            return null;
-        }
-        Long id = funding.getId();
-        if ( id == null ) {
-            return null;
-        }
-        return id;
-    }
-
-    private Long fundingRewardItemEntityFundingRewardId(FundingRewardItemEntity fundingRewardItemEntity) {
-        if ( fundingRewardItemEntity == null ) {
-            return null;
-        }
-        FundingRewardEntity fundingReward = fundingRewardItemEntity.getFundingReward();
-        if ( fundingReward == null ) {
-            return null;
-        }
-        Long id = fundingReward.getId();
-        if ( id == null ) {
-            return null;
-        }
-        return id;
-    }
-
-    private Long fundingRewardItemEntityFundingItemId(FundingRewardItemEntity fundingRewardItemEntity) {
-        if ( fundingRewardItemEntity == null ) {
-            return null;
-        }
-        FundingItemEntity fundingItem = fundingRewardItemEntity.getFundingItem();
-        if ( fundingItem == null ) {
-            return null;
-        }
-        Long id = fundingItem.getId();
-        if ( id == null ) {
-            return null;
-        }
-        return id;
     }
 }

--- a/src/main/generated/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportDeliveryPersistenceMapperImpl.java
+++ b/src/main/generated/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportDeliveryPersistenceMapperImpl.java
@@ -1,15 +1,33 @@
 package com.flab.funding.infrastructure.adapters.output.persistence.mapper;
 
+import com.flab.funding.domain.model.Funding;
+import com.flab.funding.domain.model.FundingItem;
+import com.flab.funding.domain.model.FundingItemOption;
+import com.flab.funding.domain.model.FundingReward;
+import com.flab.funding.domain.model.FundingRewardItem;
+import com.flab.funding.domain.model.FundingTag;
+import com.flab.funding.domain.model.Member;
+import com.flab.funding.domain.model.Support;
 import com.flab.funding.domain.model.SupportDelivery;
-import com.flab.funding.infrastructure.adapters.output.persistence.entity.MemberDeliveryAddressEntity;
+import com.flab.funding.domain.model.SupportPayment;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingItemEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingItemOptionEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingRewardEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingRewardItemEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingTagEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.MemberEntity;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.SupportDeliveryEntity;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.SupportEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.SupportPaymentEntity;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.processing.Generated;
 import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-24T20:52:32+0900",
+    date = "2024-03-25T18:50:00+0900",
     comments = "version: 1.5.5.Final, compiler: javac, environment: Java 17.0.9 (Oracle Corporation)"
 )
 @Component
@@ -23,9 +41,8 @@ public class SupportDeliveryPersistenceMapperImpl implements SupportDeliveryPers
 
         SupportDeliveryEntity.SupportDeliveryEntityBuilder supportDeliveryEntity = SupportDeliveryEntity.builder();
 
-        supportDeliveryEntity.support( supportDeliveryToSupportEntity( supportDelivery ) );
-        supportDeliveryEntity.memberDeliveryAddress( supportDeliveryToMemberDeliveryAddressEntity( supportDelivery ) );
         supportDeliveryEntity.id( supportDelivery.getId() );
+        supportDeliveryEntity.support( supportToSupportEntity( supportDelivery.getSupport() ) );
         supportDeliveryEntity.status( supportDelivery.getStatus() );
         supportDeliveryEntity.shipmentName( supportDelivery.getShipmentName() );
         supportDeliveryEntity.shipmentAt( supportDelivery.getShipmentAt() );
@@ -45,11 +62,8 @@ public class SupportDeliveryPersistenceMapperImpl implements SupportDeliveryPers
 
         SupportDelivery.SupportDeliveryBuilder supportDelivery = SupportDelivery.builder();
 
-        supportDelivery.supportId( supportDeliveryEntitySupportId( supportDeliveryEntity ) );
-        supportDelivery.supportKey( supportDeliveryEntitySupportSupportKey( supportDeliveryEntity ) );
-        supportDelivery.memberDeliveryAddressId( supportDeliveryEntityMemberDeliveryAddressId( supportDeliveryEntity ) );
-        supportDelivery.memberDeliveryAddressKey( supportDeliveryEntityMemberDeliveryAddressDeliveryAddressKey( supportDeliveryEntity ) );
         supportDelivery.id( supportDeliveryEntity.getId() );
+        supportDelivery.support( supportEntityToSupport( supportDeliveryEntity.getSupport() ) );
         supportDelivery.status( supportDeliveryEntity.getStatus() );
         supportDelivery.shipmentName( supportDeliveryEntity.getShipmentName() );
         supportDelivery.shipmentAt( supportDeliveryEntity.getShipmentAt() );
@@ -61,88 +75,455 @@ public class SupportDeliveryPersistenceMapperImpl implements SupportDeliveryPers
         return supportDelivery.build();
     }
 
-    protected SupportEntity supportDeliveryToSupportEntity(SupportDelivery supportDelivery) {
-        if ( supportDelivery == null ) {
+    protected MemberEntity memberToMemberEntity(Member member) {
+        if ( member == null ) {
+            return null;
+        }
+
+        MemberEntity.MemberEntityBuilder memberEntity = MemberEntity.builder();
+
+        memberEntity.id( member.getId() );
+        memberEntity.userKey( member.getUserKey() );
+        memberEntity.status( member.getStatus() );
+        memberEntity.linkType( member.getLinkType() );
+        memberEntity.email( member.getEmail() );
+        memberEntity.userName( member.getUserName() );
+        memberEntity.nickName( member.getNickName() );
+        memberEntity.phoneNumber( member.getPhoneNumber() );
+        memberEntity.gender( member.getGender() );
+        memberEntity.birthday( member.getBirthday() );
+        memberEntity.password( member.getPassword() );
+        memberEntity.lastLoginAt( member.getLastLoginAt() );
+        memberEntity.createdAt( member.getCreatedAt() );
+        memberEntity.updatedAt( member.getUpdatedAt() );
+
+        return memberEntity.build();
+    }
+
+    protected FundingTagEntity fundingTagToFundingTagEntity(FundingTag fundingTag) {
+        if ( fundingTag == null ) {
+            return null;
+        }
+
+        FundingTagEntity.FundingTagEntityBuilder fundingTagEntity = FundingTagEntity.builder();
+
+        fundingTagEntity.id( fundingTag.getId() );
+        fundingTagEntity.funding( fundingToFundingEntity( fundingTag.getFunding() ) );
+        fundingTagEntity.tag( fundingTag.getTag() );
+        fundingTagEntity.createdAt( fundingTag.getCreatedAt() );
+        fundingTagEntity.updatedAt( fundingTag.getUpdatedAt() );
+
+        return fundingTagEntity.build();
+    }
+
+    protected List<FundingTagEntity> fundingTagListToFundingTagEntityList(List<FundingTag> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<FundingTagEntity> list1 = new ArrayList<FundingTagEntity>( list.size() );
+        for ( FundingTag fundingTag : list ) {
+            list1.add( fundingTagToFundingTagEntity( fundingTag ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingEntity fundingToFundingEntity(Funding funding) {
+        if ( funding == null ) {
+            return null;
+        }
+
+        FundingEntity.FundingEntityBuilder fundingEntity = FundingEntity.builder();
+
+        fundingEntity.id( funding.getId() );
+        fundingEntity.fundingKey( funding.getFundingKey() );
+        fundingEntity.member( memberToMemberEntity( funding.getMember() ) );
+        fundingEntity.isAdult( funding.getIsAdult() );
+        fundingEntity.pricePlan( funding.getPricePlan() );
+        fundingEntity.category( funding.getCategory() );
+        fundingEntity.expectAmount( funding.getExpectAmount() );
+        fundingEntity.status( funding.getStatus() );
+        fundingEntity.title( funding.getTitle() );
+        fundingEntity.fundingDescription( funding.getFundingDescription() );
+        fundingEntity.fundingIntroduce( funding.getFundingIntroduce() );
+        fundingEntity.budgetDescription( funding.getBudgetDescription() );
+        fundingEntity.scheduleDescription( funding.getScheduleDescription() );
+        fundingEntity.teamDescription( funding.getTeamDescription() );
+        fundingEntity.rewardDescription( funding.getRewardDescription() );
+        fundingEntity.tags( fundingTagListToFundingTagEntityList( funding.getTags() ) );
+        fundingEntity.startAt( funding.getStartAt() );
+        fundingEntity.endAt( funding.getEndAt() );
+        fundingEntity.createdAt( funding.getCreatedAt() );
+        fundingEntity.createdBy( funding.getCreatedBy() );
+        fundingEntity.updatedAt( funding.getUpdatedAt() );
+        fundingEntity.updatedBy( funding.getUpdatedBy() );
+
+        return fundingEntity.build();
+    }
+
+    protected FundingItemOptionEntity fundingItemOptionToFundingItemOptionEntity(FundingItemOption fundingItemOption) {
+        if ( fundingItemOption == null ) {
+            return null;
+        }
+
+        FundingItemOptionEntity.FundingItemOptionEntityBuilder fundingItemOptionEntity = FundingItemOptionEntity.builder();
+
+        fundingItemOptionEntity.id( fundingItemOption.getId() );
+        fundingItemOptionEntity.fundingItem( fundingItemToFundingItemEntity( fundingItemOption.getFundingItem() ) );
+        fundingItemOptionEntity.createdAt( fundingItemOption.getCreatedAt() );
+        fundingItemOptionEntity.updatedAt( fundingItemOption.getUpdatedAt() );
+
+        return fundingItemOptionEntity.build();
+    }
+
+    protected List<FundingItemOptionEntity> fundingItemOptionListToFundingItemOptionEntityList(List<FundingItemOption> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<FundingItemOptionEntity> list1 = new ArrayList<FundingItemOptionEntity>( list.size() );
+        for ( FundingItemOption fundingItemOption : list ) {
+            list1.add( fundingItemOptionToFundingItemOptionEntity( fundingItemOption ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingItemEntity fundingItemToFundingItemEntity(FundingItem fundingItem) {
+        if ( fundingItem == null ) {
+            return null;
+        }
+
+        FundingItemEntity.FundingItemEntityBuilder fundingItemEntity = FundingItemEntity.builder();
+
+        fundingItemEntity.id( fundingItem.getId() );
+        fundingItemEntity.funding( fundingToFundingEntity( fundingItem.getFunding() ) );
+        fundingItemEntity.itemName( fundingItem.getItemName() );
+        fundingItemEntity.optionType( fundingItem.getOptionType() );
+        fundingItemEntity.fundingItemOptions( fundingItemOptionListToFundingItemOptionEntityList( fundingItem.getFundingItemOptions() ) );
+        fundingItemEntity.createdAt( fundingItem.getCreatedAt() );
+        fundingItemEntity.updatedAt( fundingItem.getUpdatedAt() );
+
+        return fundingItemEntity.build();
+    }
+
+    protected FundingRewardItemEntity fundingRewardItemToFundingRewardItemEntity(FundingRewardItem fundingRewardItem) {
+        if ( fundingRewardItem == null ) {
+            return null;
+        }
+
+        FundingRewardItemEntity.FundingRewardItemEntityBuilder fundingRewardItemEntity = FundingRewardItemEntity.builder();
+
+        fundingRewardItemEntity.id( fundingRewardItem.getId() );
+        fundingRewardItemEntity.funding( fundingToFundingEntity( fundingRewardItem.getFunding() ) );
+        fundingRewardItemEntity.fundingReward( fundingRewardToFundingRewardEntity( fundingRewardItem.getFundingReward() ) );
+        fundingRewardItemEntity.fundingItem( fundingItemToFundingItemEntity( fundingRewardItem.getFundingItem() ) );
+        fundingRewardItemEntity.createdAt( fundingRewardItem.getCreatedAt() );
+        fundingRewardItemEntity.updatedAt( fundingRewardItem.getUpdatedAt() );
+
+        return fundingRewardItemEntity.build();
+    }
+
+    protected List<FundingRewardItemEntity> fundingRewardItemListToFundingRewardItemEntityList(List<FundingRewardItem> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<FundingRewardItemEntity> list1 = new ArrayList<FundingRewardItemEntity>( list.size() );
+        for ( FundingRewardItem fundingRewardItem : list ) {
+            list1.add( fundingRewardItemToFundingRewardItemEntity( fundingRewardItem ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingRewardEntity fundingRewardToFundingRewardEntity(FundingReward fundingReward) {
+        if ( fundingReward == null ) {
+            return null;
+        }
+
+        FundingRewardEntity.FundingRewardEntityBuilder fundingRewardEntity = FundingRewardEntity.builder();
+
+        fundingRewardEntity.id( fundingReward.getId() );
+        fundingRewardEntity.funding( fundingToFundingEntity( fundingReward.getFunding() ) );
+        fundingRewardEntity.isDelivery( fundingReward.getIsDelivery() );
+        fundingRewardEntity.rewardTitle( fundingReward.getRewardTitle() );
+        fundingRewardEntity.amount( fundingReward.getAmount() );
+        fundingRewardEntity.fundingRewardItems( fundingRewardItemListToFundingRewardItemEntityList( fundingReward.getFundingRewardItems() ) );
+        fundingRewardEntity.countLimit( fundingReward.getCountLimit() );
+        fundingRewardEntity.personalLimit( fundingReward.getPersonalLimit() );
+        fundingRewardEntity.expectDate( fundingReward.getExpectDate() );
+        fundingRewardEntity.createdAt( fundingReward.getCreatedAt() );
+        fundingRewardEntity.updatedAt( fundingReward.getUpdatedAt() );
+
+        return fundingRewardEntity.build();
+    }
+
+    protected SupportPaymentEntity supportPaymentToSupportPaymentEntity(SupportPayment supportPayment) {
+        if ( supportPayment == null ) {
+            return null;
+        }
+
+        SupportPaymentEntity.SupportPaymentEntityBuilder supportPaymentEntity = SupportPaymentEntity.builder();
+
+        supportPaymentEntity.id( supportPayment.getId() );
+        supportPaymentEntity.support( supportToSupportEntity( supportPayment.getSupport() ) );
+        supportPaymentEntity.status( supportPayment.getStatus() );
+        supportPaymentEntity.amount( supportPayment.getAmount() );
+        supportPaymentEntity.paymentAt( supportPayment.getPaymentAt() );
+        supportPaymentEntity.createdAt( supportPayment.getCreatedAt() );
+        supportPaymentEntity.updatedAt( supportPayment.getUpdatedAt() );
+
+        return supportPaymentEntity.build();
+    }
+
+    protected SupportEntity supportToSupportEntity(Support support) {
+        if ( support == null ) {
             return null;
         }
 
         SupportEntity.SupportEntityBuilder supportEntity = SupportEntity.builder();
 
-        supportEntity.id( supportDelivery.getSupportId() );
+        supportEntity.id( support.getId() );
+        supportEntity.member( memberToMemberEntity( support.getMember() ) );
+        supportEntity.funding( fundingToFundingEntity( support.getFunding() ) );
+        supportEntity.reward( fundingRewardToFundingRewardEntity( support.getReward() ) );
+        supportEntity.supportKey( support.getSupportKey() );
+        supportEntity.status( support.getStatus() );
+        supportEntity.supportDelivery( SupportDeliveryEntity( support.getSupportDelivery() ) );
+        supportEntity.supportPayment( supportPaymentToSupportPaymentEntity( support.getSupportPayment() ) );
+        supportEntity.createdAt( support.getCreatedAt() );
+        supportEntity.createdBy( support.getCreatedBy() );
+        supportEntity.updatedAt( support.getUpdatedAt() );
+        supportEntity.updatedBy( support.getUpdatedBy() );
 
         return supportEntity.build();
     }
 
-    protected MemberDeliveryAddressEntity supportDeliveryToMemberDeliveryAddressEntity(SupportDelivery supportDelivery) {
-        if ( supportDelivery == null ) {
+    protected Member memberEntityToMember(MemberEntity memberEntity) {
+        if ( memberEntity == null ) {
             return null;
         }
 
-        MemberDeliveryAddressEntity.MemberDeliveryAddressEntityBuilder memberDeliveryAddressEntity = MemberDeliveryAddressEntity.builder();
+        Member.MemberBuilder member = Member.builder();
 
-        memberDeliveryAddressEntity.id( supportDelivery.getMemberDeliveryAddressId() );
-        memberDeliveryAddressEntity.deliveryAddressKey( supportDelivery.getMemberDeliveryAddressKey() );
+        member.id( memberEntity.getId() );
+        member.userKey( memberEntity.getUserKey() );
+        member.status( memberEntity.getStatus() );
+        member.linkType( memberEntity.getLinkType() );
+        member.email( memberEntity.getEmail() );
+        member.userName( memberEntity.getUserName() );
+        member.nickName( memberEntity.getNickName() );
+        member.phoneNumber( memberEntity.getPhoneNumber() );
+        member.gender( memberEntity.getGender() );
+        member.birthday( memberEntity.getBirthday() );
+        member.password( memberEntity.getPassword() );
+        member.lastLoginAt( memberEntity.getLastLoginAt() );
+        member.createdAt( memberEntity.getCreatedAt() );
+        member.updatedAt( memberEntity.getUpdatedAt() );
 
-        return memberDeliveryAddressEntity.build();
+        return member.build();
     }
 
-    private Long supportDeliveryEntitySupportId(SupportDeliveryEntity supportDeliveryEntity) {
-        if ( supportDeliveryEntity == null ) {
+    protected FundingTag fundingTagEntityToFundingTag(FundingTagEntity fundingTagEntity) {
+        if ( fundingTagEntity == null ) {
             return null;
         }
-        SupportEntity support = supportDeliveryEntity.getSupport();
-        if ( support == null ) {
-            return null;
-        }
-        Long id = support.getId();
-        if ( id == null ) {
-            return null;
-        }
-        return id;
+
+        FundingTag.FundingTagBuilder fundingTag = FundingTag.builder();
+
+        fundingTag.id( fundingTagEntity.getId() );
+        fundingTag.funding( fundingEntityToFunding( fundingTagEntity.getFunding() ) );
+        fundingTag.tag( fundingTagEntity.getTag() );
+        fundingTag.createdAt( fundingTagEntity.getCreatedAt() );
+        fundingTag.updatedAt( fundingTagEntity.getUpdatedAt() );
+
+        return fundingTag.build();
     }
 
-    private String supportDeliveryEntitySupportSupportKey(SupportDeliveryEntity supportDeliveryEntity) {
-        if ( supportDeliveryEntity == null ) {
+    protected List<FundingTag> fundingTagEntityListToFundingTagList(List<FundingTagEntity> list) {
+        if ( list == null ) {
             return null;
         }
-        SupportEntity support = supportDeliveryEntity.getSupport();
-        if ( support == null ) {
-            return null;
+
+        List<FundingTag> list1 = new ArrayList<FundingTag>( list.size() );
+        for ( FundingTagEntity fundingTagEntity : list ) {
+            list1.add( fundingTagEntityToFundingTag( fundingTagEntity ) );
         }
-        String supportKey = support.getSupportKey();
-        if ( supportKey == null ) {
-            return null;
-        }
-        return supportKey;
+
+        return list1;
     }
 
-    private Long supportDeliveryEntityMemberDeliveryAddressId(SupportDeliveryEntity supportDeliveryEntity) {
-        if ( supportDeliveryEntity == null ) {
+    protected Funding fundingEntityToFunding(FundingEntity fundingEntity) {
+        if ( fundingEntity == null ) {
             return null;
         }
-        MemberDeliveryAddressEntity memberDeliveryAddress = supportDeliveryEntity.getMemberDeliveryAddress();
-        if ( memberDeliveryAddress == null ) {
-            return null;
-        }
-        Long id = memberDeliveryAddress.getId();
-        if ( id == null ) {
-            return null;
-        }
-        return id;
+
+        Funding.FundingBuilder funding = Funding.builder();
+
+        funding.id( fundingEntity.getId() );
+        funding.fundingKey( fundingEntity.getFundingKey() );
+        funding.member( memberEntityToMember( fundingEntity.getMember() ) );
+        funding.isAdult( fundingEntity.getIsAdult() );
+        funding.pricePlan( fundingEntity.getPricePlan() );
+        funding.category( fundingEntity.getCategory() );
+        funding.expectAmount( fundingEntity.getExpectAmount() );
+        funding.status( fundingEntity.getStatus() );
+        funding.title( fundingEntity.getTitle() );
+        funding.fundingDescription( fundingEntity.getFundingDescription() );
+        funding.fundingIntroduce( fundingEntity.getFundingIntroduce() );
+        funding.budgetDescription( fundingEntity.getBudgetDescription() );
+        funding.scheduleDescription( fundingEntity.getScheduleDescription() );
+        funding.teamDescription( fundingEntity.getTeamDescription() );
+        funding.rewardDescription( fundingEntity.getRewardDescription() );
+        funding.tags( fundingTagEntityListToFundingTagList( fundingEntity.getTags() ) );
+        funding.startAt( fundingEntity.getStartAt() );
+        funding.endAt( fundingEntity.getEndAt() );
+        funding.createdAt( fundingEntity.getCreatedAt() );
+        funding.createdBy( fundingEntity.getCreatedBy() );
+        funding.updatedAt( fundingEntity.getUpdatedAt() );
+        funding.updatedBy( fundingEntity.getUpdatedBy() );
+
+        return funding.build();
     }
 
-    private String supportDeliveryEntityMemberDeliveryAddressDeliveryAddressKey(SupportDeliveryEntity supportDeliveryEntity) {
-        if ( supportDeliveryEntity == null ) {
+    protected FundingItemOption fundingItemOptionEntityToFundingItemOption(FundingItemOptionEntity fundingItemOptionEntity) {
+        if ( fundingItemOptionEntity == null ) {
             return null;
         }
-        MemberDeliveryAddressEntity memberDeliveryAddress = supportDeliveryEntity.getMemberDeliveryAddress();
-        if ( memberDeliveryAddress == null ) {
+
+        FundingItemOption.FundingItemOptionBuilder fundingItemOption = FundingItemOption.builder();
+
+        fundingItemOption.id( fundingItemOptionEntity.getId() );
+        fundingItemOption.fundingItem( fundingItemEntityToFundingItem( fundingItemOptionEntity.getFundingItem() ) );
+        fundingItemOption.createdAt( fundingItemOptionEntity.getCreatedAt() );
+        fundingItemOption.updatedAt( fundingItemOptionEntity.getUpdatedAt() );
+
+        return fundingItemOption.build();
+    }
+
+    protected List<FundingItemOption> fundingItemOptionEntityListToFundingItemOptionList(List<FundingItemOptionEntity> list) {
+        if ( list == null ) {
             return null;
         }
-        String deliveryAddressKey = memberDeliveryAddress.getDeliveryAddressKey();
-        if ( deliveryAddressKey == null ) {
+
+        List<FundingItemOption> list1 = new ArrayList<FundingItemOption>( list.size() );
+        for ( FundingItemOptionEntity fundingItemOptionEntity : list ) {
+            list1.add( fundingItemOptionEntityToFundingItemOption( fundingItemOptionEntity ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingItem fundingItemEntityToFundingItem(FundingItemEntity fundingItemEntity) {
+        if ( fundingItemEntity == null ) {
             return null;
         }
-        return deliveryAddressKey;
+
+        FundingItem.FundingItemBuilder fundingItem = FundingItem.builder();
+
+        fundingItem.id( fundingItemEntity.getId() );
+        fundingItem.funding( fundingEntityToFunding( fundingItemEntity.getFunding() ) );
+        fundingItem.itemName( fundingItemEntity.getItemName() );
+        fundingItem.optionType( fundingItemEntity.getOptionType() );
+        fundingItem.fundingItemOptions( fundingItemOptionEntityListToFundingItemOptionList( fundingItemEntity.getFundingItemOptions() ) );
+        fundingItem.createdAt( fundingItemEntity.getCreatedAt() );
+        fundingItem.updatedAt( fundingItemEntity.getUpdatedAt() );
+
+        return fundingItem.build();
+    }
+
+    protected FundingRewardItem fundingRewardItemEntityToFundingRewardItem(FundingRewardItemEntity fundingRewardItemEntity) {
+        if ( fundingRewardItemEntity == null ) {
+            return null;
+        }
+
+        FundingRewardItem.FundingRewardItemBuilder fundingRewardItem = FundingRewardItem.builder();
+
+        fundingRewardItem.id( fundingRewardItemEntity.getId() );
+        fundingRewardItem.funding( fundingEntityToFunding( fundingRewardItemEntity.getFunding() ) );
+        fundingRewardItem.fundingReward( fundingRewardEntityToFundingReward( fundingRewardItemEntity.getFundingReward() ) );
+        fundingRewardItem.fundingItem( fundingItemEntityToFundingItem( fundingRewardItemEntity.getFundingItem() ) );
+        fundingRewardItem.createdAt( fundingRewardItemEntity.getCreatedAt() );
+        fundingRewardItem.updatedAt( fundingRewardItemEntity.getUpdatedAt() );
+
+        return fundingRewardItem.build();
+    }
+
+    protected List<FundingRewardItem> fundingRewardItemEntityListToFundingRewardItemList(List<FundingRewardItemEntity> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<FundingRewardItem> list1 = new ArrayList<FundingRewardItem>( list.size() );
+        for ( FundingRewardItemEntity fundingRewardItemEntity : list ) {
+            list1.add( fundingRewardItemEntityToFundingRewardItem( fundingRewardItemEntity ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingReward fundingRewardEntityToFundingReward(FundingRewardEntity fundingRewardEntity) {
+        if ( fundingRewardEntity == null ) {
+            return null;
+        }
+
+        FundingReward.FundingRewardBuilder fundingReward = FundingReward.builder();
+
+        fundingReward.id( fundingRewardEntity.getId() );
+        fundingReward.funding( fundingEntityToFunding( fundingRewardEntity.getFunding() ) );
+        fundingReward.isDelivery( fundingRewardEntity.getIsDelivery() );
+        fundingReward.rewardTitle( fundingRewardEntity.getRewardTitle() );
+        fundingReward.amount( fundingRewardEntity.getAmount() );
+        fundingReward.fundingRewardItems( fundingRewardItemEntityListToFundingRewardItemList( fundingRewardEntity.getFundingRewardItems() ) );
+        fundingReward.countLimit( fundingRewardEntity.getCountLimit() );
+        fundingReward.personalLimit( fundingRewardEntity.getPersonalLimit() );
+        fundingReward.expectDate( fundingRewardEntity.getExpectDate() );
+        fundingReward.createdAt( fundingRewardEntity.getCreatedAt() );
+        fundingReward.updatedAt( fundingRewardEntity.getUpdatedAt() );
+
+        return fundingReward.build();
+    }
+
+    protected SupportPayment supportPaymentEntityToSupportPayment(SupportPaymentEntity supportPaymentEntity) {
+        if ( supportPaymentEntity == null ) {
+            return null;
+        }
+
+        SupportPayment.SupportPaymentBuilder supportPayment = SupportPayment.builder();
+
+        supportPayment.id( supportPaymentEntity.getId() );
+        supportPayment.support( supportEntityToSupport( supportPaymentEntity.getSupport() ) );
+        supportPayment.status( supportPaymentEntity.getStatus() );
+        supportPayment.amount( supportPaymentEntity.getAmount() );
+        supportPayment.paymentAt( supportPaymentEntity.getPaymentAt() );
+        supportPayment.createdAt( supportPaymentEntity.getCreatedAt() );
+        supportPayment.updatedAt( supportPaymentEntity.getUpdatedAt() );
+
+        return supportPayment.build();
+    }
+
+    protected Support supportEntityToSupport(SupportEntity supportEntity) {
+        if ( supportEntity == null ) {
+            return null;
+        }
+
+        Support.SupportBuilder support = Support.builder();
+
+        support.id( supportEntity.getId() );
+        support.member( memberEntityToMember( supportEntity.getMember() ) );
+        support.funding( fundingEntityToFunding( supportEntity.getFunding() ) );
+        support.reward( fundingRewardEntityToFundingReward( supportEntity.getReward() ) );
+        support.supportKey( supportEntity.getSupportKey() );
+        support.status( supportEntity.getStatus() );
+        support.supportDelivery( toSupportDelivery( supportEntity.getSupportDelivery() ) );
+        support.supportPayment( supportPaymentEntityToSupportPayment( supportEntity.getSupportPayment() ) );
+        support.createdAt( supportEntity.getCreatedAt() );
+        support.createdBy( supportEntity.getCreatedBy() );
+        support.updatedAt( supportEntity.getUpdatedAt() );
+        support.updatedBy( supportEntity.getUpdatedBy() );
+
+        return support.build();
     }
 }

--- a/src/main/generated/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportDeliveryPersistenceMapperImpl.java
+++ b/src/main/generated/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportDeliveryPersistenceMapperImpl.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-17T20:12:32+0900",
+    date = "2024-03-24T20:52:32+0900",
     comments = "version: 1.5.5.Final, compiler: javac, environment: Java 17.0.9 (Oracle Corporation)"
 )
 @Component
@@ -48,6 +48,7 @@ public class SupportDeliveryPersistenceMapperImpl implements SupportDeliveryPers
         supportDelivery.supportId( supportDeliveryEntitySupportId( supportDeliveryEntity ) );
         supportDelivery.supportKey( supportDeliveryEntitySupportSupportKey( supportDeliveryEntity ) );
         supportDelivery.memberDeliveryAddressId( supportDeliveryEntityMemberDeliveryAddressId( supportDeliveryEntity ) );
+        supportDelivery.memberDeliveryAddressKey( supportDeliveryEntityMemberDeliveryAddressDeliveryAddressKey( supportDeliveryEntity ) );
         supportDelivery.id( supportDeliveryEntity.getId() );
         supportDelivery.status( supportDeliveryEntity.getStatus() );
         supportDelivery.shipmentName( supportDeliveryEntity.getShipmentName() );
@@ -80,6 +81,7 @@ public class SupportDeliveryPersistenceMapperImpl implements SupportDeliveryPers
         MemberDeliveryAddressEntity.MemberDeliveryAddressEntityBuilder memberDeliveryAddressEntity = MemberDeliveryAddressEntity.builder();
 
         memberDeliveryAddressEntity.id( supportDelivery.getMemberDeliveryAddressId() );
+        memberDeliveryAddressEntity.deliveryAddressKey( supportDelivery.getMemberDeliveryAddressKey() );
 
         return memberDeliveryAddressEntity.build();
     }
@@ -127,5 +129,20 @@ public class SupportDeliveryPersistenceMapperImpl implements SupportDeliveryPers
             return null;
         }
         return id;
+    }
+
+    private String supportDeliveryEntityMemberDeliveryAddressDeliveryAddressKey(SupportDeliveryEntity supportDeliveryEntity) {
+        if ( supportDeliveryEntity == null ) {
+            return null;
+        }
+        MemberDeliveryAddressEntity memberDeliveryAddress = supportDeliveryEntity.getMemberDeliveryAddress();
+        if ( memberDeliveryAddress == null ) {
+            return null;
+        }
+        String deliveryAddressKey = memberDeliveryAddress.getDeliveryAddressKey();
+        if ( deliveryAddressKey == null ) {
+            return null;
+        }
+        return deliveryAddressKey;
     }
 }

--- a/src/main/generated/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportPaymentPersistenceMapperImpl.java
+++ b/src/main/generated/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportPaymentPersistenceMapperImpl.java
@@ -1,15 +1,33 @@
 package com.flab.funding.infrastructure.adapters.output.persistence.mapper;
 
+import com.flab.funding.domain.model.Funding;
+import com.flab.funding.domain.model.FundingItem;
+import com.flab.funding.domain.model.FundingItemOption;
+import com.flab.funding.domain.model.FundingReward;
+import com.flab.funding.domain.model.FundingRewardItem;
+import com.flab.funding.domain.model.FundingTag;
+import com.flab.funding.domain.model.Member;
+import com.flab.funding.domain.model.Support;
+import com.flab.funding.domain.model.SupportDelivery;
 import com.flab.funding.domain.model.SupportPayment;
-import com.flab.funding.infrastructure.adapters.output.persistence.entity.MemberPaymentMethodEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingItemEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingItemOptionEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingRewardEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingRewardItemEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingTagEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.MemberEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.SupportDeliveryEntity;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.SupportEntity;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.SupportPaymentEntity;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.processing.Generated;
 import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-24T20:52:32+0900",
+    date = "2024-03-25T18:49:59+0900",
     comments = "version: 1.5.5.Final, compiler: javac, environment: Java 17.0.9 (Oracle Corporation)"
 )
 @Component
@@ -23,9 +41,8 @@ public class SupportPaymentPersistenceMapperImpl implements SupportPaymentPersis
 
         SupportPaymentEntity.SupportPaymentEntityBuilder supportPaymentEntity = SupportPaymentEntity.builder();
 
-        supportPaymentEntity.support( supportPaymentToSupportEntity( supportPayment ) );
-        supportPaymentEntity.memberPaymentMethod( supportPaymentToMemberPaymentMethodEntity( supportPayment ) );
         supportPaymentEntity.id( supportPayment.getId() );
+        supportPaymentEntity.support( supportToSupportEntity( supportPayment.getSupport() ) );
         supportPaymentEntity.status( supportPayment.getStatus() );
         supportPaymentEntity.amount( supportPayment.getAmount() );
         supportPaymentEntity.paymentAt( supportPayment.getPaymentAt() );
@@ -43,10 +60,8 @@ public class SupportPaymentPersistenceMapperImpl implements SupportPaymentPersis
 
         SupportPayment.SupportPaymentBuilder supportPayment = SupportPayment.builder();
 
-        supportPayment.supportId( supportPaymentEntitySupportId( supportPaymentEntity ) );
-        supportPayment.memberPaymentMethodId( supportPaymentEntityMemberPaymentMethodId( supportPaymentEntity ) );
-        supportPayment.memberPaymentMethodKey( supportPaymentEntityMemberPaymentMethodPaymentMethodKey( supportPaymentEntity ) );
         supportPayment.id( supportPaymentEntity.getId() );
+        supportPayment.support( supportEntityToSupport( supportPaymentEntity.getSupport() ) );
         supportPayment.status( supportPaymentEntity.getStatus() );
         supportPayment.amount( supportPaymentEntity.getAmount() );
         supportPayment.paymentAt( supportPaymentEntity.getPaymentAt() );
@@ -56,73 +71,459 @@ public class SupportPaymentPersistenceMapperImpl implements SupportPaymentPersis
         return supportPayment.build();
     }
 
-    protected SupportEntity supportPaymentToSupportEntity(SupportPayment supportPayment) {
-        if ( supportPayment == null ) {
+    protected MemberEntity memberToMemberEntity(Member member) {
+        if ( member == null ) {
+            return null;
+        }
+
+        MemberEntity.MemberEntityBuilder memberEntity = MemberEntity.builder();
+
+        memberEntity.id( member.getId() );
+        memberEntity.userKey( member.getUserKey() );
+        memberEntity.status( member.getStatus() );
+        memberEntity.linkType( member.getLinkType() );
+        memberEntity.email( member.getEmail() );
+        memberEntity.userName( member.getUserName() );
+        memberEntity.nickName( member.getNickName() );
+        memberEntity.phoneNumber( member.getPhoneNumber() );
+        memberEntity.gender( member.getGender() );
+        memberEntity.birthday( member.getBirthday() );
+        memberEntity.password( member.getPassword() );
+        memberEntity.lastLoginAt( member.getLastLoginAt() );
+        memberEntity.createdAt( member.getCreatedAt() );
+        memberEntity.updatedAt( member.getUpdatedAt() );
+
+        return memberEntity.build();
+    }
+
+    protected FundingTagEntity fundingTagToFundingTagEntity(FundingTag fundingTag) {
+        if ( fundingTag == null ) {
+            return null;
+        }
+
+        FundingTagEntity.FundingTagEntityBuilder fundingTagEntity = FundingTagEntity.builder();
+
+        fundingTagEntity.id( fundingTag.getId() );
+        fundingTagEntity.funding( fundingToFundingEntity( fundingTag.getFunding() ) );
+        fundingTagEntity.tag( fundingTag.getTag() );
+        fundingTagEntity.createdAt( fundingTag.getCreatedAt() );
+        fundingTagEntity.updatedAt( fundingTag.getUpdatedAt() );
+
+        return fundingTagEntity.build();
+    }
+
+    protected List<FundingTagEntity> fundingTagListToFundingTagEntityList(List<FundingTag> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<FundingTagEntity> list1 = new ArrayList<FundingTagEntity>( list.size() );
+        for ( FundingTag fundingTag : list ) {
+            list1.add( fundingTagToFundingTagEntity( fundingTag ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingEntity fundingToFundingEntity(Funding funding) {
+        if ( funding == null ) {
+            return null;
+        }
+
+        FundingEntity.FundingEntityBuilder fundingEntity = FundingEntity.builder();
+
+        fundingEntity.id( funding.getId() );
+        fundingEntity.fundingKey( funding.getFundingKey() );
+        fundingEntity.member( memberToMemberEntity( funding.getMember() ) );
+        fundingEntity.isAdult( funding.getIsAdult() );
+        fundingEntity.pricePlan( funding.getPricePlan() );
+        fundingEntity.category( funding.getCategory() );
+        fundingEntity.expectAmount( funding.getExpectAmount() );
+        fundingEntity.status( funding.getStatus() );
+        fundingEntity.title( funding.getTitle() );
+        fundingEntity.fundingDescription( funding.getFundingDescription() );
+        fundingEntity.fundingIntroduce( funding.getFundingIntroduce() );
+        fundingEntity.budgetDescription( funding.getBudgetDescription() );
+        fundingEntity.scheduleDescription( funding.getScheduleDescription() );
+        fundingEntity.teamDescription( funding.getTeamDescription() );
+        fundingEntity.rewardDescription( funding.getRewardDescription() );
+        fundingEntity.tags( fundingTagListToFundingTagEntityList( funding.getTags() ) );
+        fundingEntity.startAt( funding.getStartAt() );
+        fundingEntity.endAt( funding.getEndAt() );
+        fundingEntity.createdAt( funding.getCreatedAt() );
+        fundingEntity.createdBy( funding.getCreatedBy() );
+        fundingEntity.updatedAt( funding.getUpdatedAt() );
+        fundingEntity.updatedBy( funding.getUpdatedBy() );
+
+        return fundingEntity.build();
+    }
+
+    protected FundingItemOptionEntity fundingItemOptionToFundingItemOptionEntity(FundingItemOption fundingItemOption) {
+        if ( fundingItemOption == null ) {
+            return null;
+        }
+
+        FundingItemOptionEntity.FundingItemOptionEntityBuilder fundingItemOptionEntity = FundingItemOptionEntity.builder();
+
+        fundingItemOptionEntity.id( fundingItemOption.getId() );
+        fundingItemOptionEntity.fundingItem( fundingItemToFundingItemEntity( fundingItemOption.getFundingItem() ) );
+        fundingItemOptionEntity.createdAt( fundingItemOption.getCreatedAt() );
+        fundingItemOptionEntity.updatedAt( fundingItemOption.getUpdatedAt() );
+
+        return fundingItemOptionEntity.build();
+    }
+
+    protected List<FundingItemOptionEntity> fundingItemOptionListToFundingItemOptionEntityList(List<FundingItemOption> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<FundingItemOptionEntity> list1 = new ArrayList<FundingItemOptionEntity>( list.size() );
+        for ( FundingItemOption fundingItemOption : list ) {
+            list1.add( fundingItemOptionToFundingItemOptionEntity( fundingItemOption ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingItemEntity fundingItemToFundingItemEntity(FundingItem fundingItem) {
+        if ( fundingItem == null ) {
+            return null;
+        }
+
+        FundingItemEntity.FundingItemEntityBuilder fundingItemEntity = FundingItemEntity.builder();
+
+        fundingItemEntity.id( fundingItem.getId() );
+        fundingItemEntity.funding( fundingToFundingEntity( fundingItem.getFunding() ) );
+        fundingItemEntity.itemName( fundingItem.getItemName() );
+        fundingItemEntity.optionType( fundingItem.getOptionType() );
+        fundingItemEntity.fundingItemOptions( fundingItemOptionListToFundingItemOptionEntityList( fundingItem.getFundingItemOptions() ) );
+        fundingItemEntity.createdAt( fundingItem.getCreatedAt() );
+        fundingItemEntity.updatedAt( fundingItem.getUpdatedAt() );
+
+        return fundingItemEntity.build();
+    }
+
+    protected FundingRewardItemEntity fundingRewardItemToFundingRewardItemEntity(FundingRewardItem fundingRewardItem) {
+        if ( fundingRewardItem == null ) {
+            return null;
+        }
+
+        FundingRewardItemEntity.FundingRewardItemEntityBuilder fundingRewardItemEntity = FundingRewardItemEntity.builder();
+
+        fundingRewardItemEntity.id( fundingRewardItem.getId() );
+        fundingRewardItemEntity.funding( fundingToFundingEntity( fundingRewardItem.getFunding() ) );
+        fundingRewardItemEntity.fundingReward( fundingRewardToFundingRewardEntity( fundingRewardItem.getFundingReward() ) );
+        fundingRewardItemEntity.fundingItem( fundingItemToFundingItemEntity( fundingRewardItem.getFundingItem() ) );
+        fundingRewardItemEntity.createdAt( fundingRewardItem.getCreatedAt() );
+        fundingRewardItemEntity.updatedAt( fundingRewardItem.getUpdatedAt() );
+
+        return fundingRewardItemEntity.build();
+    }
+
+    protected List<FundingRewardItemEntity> fundingRewardItemListToFundingRewardItemEntityList(List<FundingRewardItem> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<FundingRewardItemEntity> list1 = new ArrayList<FundingRewardItemEntity>( list.size() );
+        for ( FundingRewardItem fundingRewardItem : list ) {
+            list1.add( fundingRewardItemToFundingRewardItemEntity( fundingRewardItem ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingRewardEntity fundingRewardToFundingRewardEntity(FundingReward fundingReward) {
+        if ( fundingReward == null ) {
+            return null;
+        }
+
+        FundingRewardEntity.FundingRewardEntityBuilder fundingRewardEntity = FundingRewardEntity.builder();
+
+        fundingRewardEntity.id( fundingReward.getId() );
+        fundingRewardEntity.funding( fundingToFundingEntity( fundingReward.getFunding() ) );
+        fundingRewardEntity.isDelivery( fundingReward.getIsDelivery() );
+        fundingRewardEntity.rewardTitle( fundingReward.getRewardTitle() );
+        fundingRewardEntity.amount( fundingReward.getAmount() );
+        fundingRewardEntity.fundingRewardItems( fundingRewardItemListToFundingRewardItemEntityList( fundingReward.getFundingRewardItems() ) );
+        fundingRewardEntity.countLimit( fundingReward.getCountLimit() );
+        fundingRewardEntity.personalLimit( fundingReward.getPersonalLimit() );
+        fundingRewardEntity.expectDate( fundingReward.getExpectDate() );
+        fundingRewardEntity.createdAt( fundingReward.getCreatedAt() );
+        fundingRewardEntity.updatedAt( fundingReward.getUpdatedAt() );
+
+        return fundingRewardEntity.build();
+    }
+
+    protected SupportDeliveryEntity supportDeliveryToSupportDeliveryEntity(SupportDelivery supportDelivery) {
+        if ( supportDelivery == null ) {
+            return null;
+        }
+
+        SupportDeliveryEntity.SupportDeliveryEntityBuilder supportDeliveryEntity = SupportDeliveryEntity.builder();
+
+        supportDeliveryEntity.id( supportDelivery.getId() );
+        supportDeliveryEntity.support( supportToSupportEntity( supportDelivery.getSupport() ) );
+        supportDeliveryEntity.status( supportDelivery.getStatus() );
+        supportDeliveryEntity.shipmentName( supportDelivery.getShipmentName() );
+        supportDeliveryEntity.shipmentAt( supportDelivery.getShipmentAt() );
+        supportDeliveryEntity.trackingName( supportDelivery.getTrackingName() );
+        supportDeliveryEntity.trackingAt( supportDelivery.getTrackingAt() );
+        supportDeliveryEntity.createdAt( supportDelivery.getCreatedAt() );
+        supportDeliveryEntity.updatedAt( supportDelivery.getUpdatedAt() );
+
+        return supportDeliveryEntity.build();
+    }
+
+    protected SupportEntity supportToSupportEntity(Support support) {
+        if ( support == null ) {
             return null;
         }
 
         SupportEntity.SupportEntityBuilder supportEntity = SupportEntity.builder();
 
-        supportEntity.id( supportPayment.getSupportId() );
+        supportEntity.id( support.getId() );
+        supportEntity.member( memberToMemberEntity( support.getMember() ) );
+        supportEntity.funding( fundingToFundingEntity( support.getFunding() ) );
+        supportEntity.reward( fundingRewardToFundingRewardEntity( support.getReward() ) );
+        supportEntity.supportKey( support.getSupportKey() );
+        supportEntity.status( support.getStatus() );
+        supportEntity.supportDelivery( supportDeliveryToSupportDeliveryEntity( support.getSupportDelivery() ) );
+        supportEntity.supportPayment( toSupportPaymentEntity( support.getSupportPayment() ) );
+        supportEntity.createdAt( support.getCreatedAt() );
+        supportEntity.createdBy( support.getCreatedBy() );
+        supportEntity.updatedAt( support.getUpdatedAt() );
+        supportEntity.updatedBy( support.getUpdatedBy() );
 
         return supportEntity.build();
     }
 
-    protected MemberPaymentMethodEntity supportPaymentToMemberPaymentMethodEntity(SupportPayment supportPayment) {
-        if ( supportPayment == null ) {
+    protected Member memberEntityToMember(MemberEntity memberEntity) {
+        if ( memberEntity == null ) {
             return null;
         }
 
-        MemberPaymentMethodEntity.MemberPaymentMethodEntityBuilder<?, ?> memberPaymentMethodEntity = MemberPaymentMethodEntity.builder();
+        Member.MemberBuilder member = Member.builder();
 
-        memberPaymentMethodEntity.id( supportPayment.getMemberPaymentMethodId() );
-        memberPaymentMethodEntity.paymentMethodKey( supportPayment.getMemberPaymentMethodKey() );
+        member.id( memberEntity.getId() );
+        member.userKey( memberEntity.getUserKey() );
+        member.status( memberEntity.getStatus() );
+        member.linkType( memberEntity.getLinkType() );
+        member.email( memberEntity.getEmail() );
+        member.userName( memberEntity.getUserName() );
+        member.nickName( memberEntity.getNickName() );
+        member.phoneNumber( memberEntity.getPhoneNumber() );
+        member.gender( memberEntity.getGender() );
+        member.birthday( memberEntity.getBirthday() );
+        member.password( memberEntity.getPassword() );
+        member.lastLoginAt( memberEntity.getLastLoginAt() );
+        member.createdAt( memberEntity.getCreatedAt() );
+        member.updatedAt( memberEntity.getUpdatedAt() );
 
-        return memberPaymentMethodEntity.build();
+        return member.build();
     }
 
-    private Long supportPaymentEntitySupportId(SupportPaymentEntity supportPaymentEntity) {
-        if ( supportPaymentEntity == null ) {
+    protected FundingTag fundingTagEntityToFundingTag(FundingTagEntity fundingTagEntity) {
+        if ( fundingTagEntity == null ) {
             return null;
         }
-        SupportEntity support = supportPaymentEntity.getSupport();
-        if ( support == null ) {
-            return null;
-        }
-        Long id = support.getId();
-        if ( id == null ) {
-            return null;
-        }
-        return id;
+
+        FundingTag.FundingTagBuilder fundingTag = FundingTag.builder();
+
+        fundingTag.id( fundingTagEntity.getId() );
+        fundingTag.funding( fundingEntityToFunding( fundingTagEntity.getFunding() ) );
+        fundingTag.tag( fundingTagEntity.getTag() );
+        fundingTag.createdAt( fundingTagEntity.getCreatedAt() );
+        fundingTag.updatedAt( fundingTagEntity.getUpdatedAt() );
+
+        return fundingTag.build();
     }
 
-    private Long supportPaymentEntityMemberPaymentMethodId(SupportPaymentEntity supportPaymentEntity) {
-        if ( supportPaymentEntity == null ) {
+    protected List<FundingTag> fundingTagEntityListToFundingTagList(List<FundingTagEntity> list) {
+        if ( list == null ) {
             return null;
         }
-        MemberPaymentMethodEntity memberPaymentMethod = supportPaymentEntity.getMemberPaymentMethod();
-        if ( memberPaymentMethod == null ) {
-            return null;
+
+        List<FundingTag> list1 = new ArrayList<FundingTag>( list.size() );
+        for ( FundingTagEntity fundingTagEntity : list ) {
+            list1.add( fundingTagEntityToFundingTag( fundingTagEntity ) );
         }
-        Long id = memberPaymentMethod.getId();
-        if ( id == null ) {
-            return null;
-        }
-        return id;
+
+        return list1;
     }
 
-    private String supportPaymentEntityMemberPaymentMethodPaymentMethodKey(SupportPaymentEntity supportPaymentEntity) {
-        if ( supportPaymentEntity == null ) {
+    protected Funding fundingEntityToFunding(FundingEntity fundingEntity) {
+        if ( fundingEntity == null ) {
             return null;
         }
-        MemberPaymentMethodEntity memberPaymentMethod = supportPaymentEntity.getMemberPaymentMethod();
-        if ( memberPaymentMethod == null ) {
+
+        Funding.FundingBuilder funding = Funding.builder();
+
+        funding.id( fundingEntity.getId() );
+        funding.fundingKey( fundingEntity.getFundingKey() );
+        funding.member( memberEntityToMember( fundingEntity.getMember() ) );
+        funding.isAdult( fundingEntity.getIsAdult() );
+        funding.pricePlan( fundingEntity.getPricePlan() );
+        funding.category( fundingEntity.getCategory() );
+        funding.expectAmount( fundingEntity.getExpectAmount() );
+        funding.status( fundingEntity.getStatus() );
+        funding.title( fundingEntity.getTitle() );
+        funding.fundingDescription( fundingEntity.getFundingDescription() );
+        funding.fundingIntroduce( fundingEntity.getFundingIntroduce() );
+        funding.budgetDescription( fundingEntity.getBudgetDescription() );
+        funding.scheduleDescription( fundingEntity.getScheduleDescription() );
+        funding.teamDescription( fundingEntity.getTeamDescription() );
+        funding.rewardDescription( fundingEntity.getRewardDescription() );
+        funding.tags( fundingTagEntityListToFundingTagList( fundingEntity.getTags() ) );
+        funding.startAt( fundingEntity.getStartAt() );
+        funding.endAt( fundingEntity.getEndAt() );
+        funding.createdAt( fundingEntity.getCreatedAt() );
+        funding.createdBy( fundingEntity.getCreatedBy() );
+        funding.updatedAt( fundingEntity.getUpdatedAt() );
+        funding.updatedBy( fundingEntity.getUpdatedBy() );
+
+        return funding.build();
+    }
+
+    protected FundingItemOption fundingItemOptionEntityToFundingItemOption(FundingItemOptionEntity fundingItemOptionEntity) {
+        if ( fundingItemOptionEntity == null ) {
             return null;
         }
-        String paymentMethodKey = memberPaymentMethod.getPaymentMethodKey();
-        if ( paymentMethodKey == null ) {
+
+        FundingItemOption.FundingItemOptionBuilder fundingItemOption = FundingItemOption.builder();
+
+        fundingItemOption.id( fundingItemOptionEntity.getId() );
+        fundingItemOption.fundingItem( fundingItemEntityToFundingItem( fundingItemOptionEntity.getFundingItem() ) );
+        fundingItemOption.createdAt( fundingItemOptionEntity.getCreatedAt() );
+        fundingItemOption.updatedAt( fundingItemOptionEntity.getUpdatedAt() );
+
+        return fundingItemOption.build();
+    }
+
+    protected List<FundingItemOption> fundingItemOptionEntityListToFundingItemOptionList(List<FundingItemOptionEntity> list) {
+        if ( list == null ) {
             return null;
         }
-        return paymentMethodKey;
+
+        List<FundingItemOption> list1 = new ArrayList<FundingItemOption>( list.size() );
+        for ( FundingItemOptionEntity fundingItemOptionEntity : list ) {
+            list1.add( fundingItemOptionEntityToFundingItemOption( fundingItemOptionEntity ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingItem fundingItemEntityToFundingItem(FundingItemEntity fundingItemEntity) {
+        if ( fundingItemEntity == null ) {
+            return null;
+        }
+
+        FundingItem.FundingItemBuilder fundingItem = FundingItem.builder();
+
+        fundingItem.id( fundingItemEntity.getId() );
+        fundingItem.funding( fundingEntityToFunding( fundingItemEntity.getFunding() ) );
+        fundingItem.itemName( fundingItemEntity.getItemName() );
+        fundingItem.optionType( fundingItemEntity.getOptionType() );
+        fundingItem.fundingItemOptions( fundingItemOptionEntityListToFundingItemOptionList( fundingItemEntity.getFundingItemOptions() ) );
+        fundingItem.createdAt( fundingItemEntity.getCreatedAt() );
+        fundingItem.updatedAt( fundingItemEntity.getUpdatedAt() );
+
+        return fundingItem.build();
+    }
+
+    protected FundingRewardItem fundingRewardItemEntityToFundingRewardItem(FundingRewardItemEntity fundingRewardItemEntity) {
+        if ( fundingRewardItemEntity == null ) {
+            return null;
+        }
+
+        FundingRewardItem.FundingRewardItemBuilder fundingRewardItem = FundingRewardItem.builder();
+
+        fundingRewardItem.id( fundingRewardItemEntity.getId() );
+        fundingRewardItem.funding( fundingEntityToFunding( fundingRewardItemEntity.getFunding() ) );
+        fundingRewardItem.fundingReward( fundingRewardEntityToFundingReward( fundingRewardItemEntity.getFundingReward() ) );
+        fundingRewardItem.fundingItem( fundingItemEntityToFundingItem( fundingRewardItemEntity.getFundingItem() ) );
+        fundingRewardItem.createdAt( fundingRewardItemEntity.getCreatedAt() );
+        fundingRewardItem.updatedAt( fundingRewardItemEntity.getUpdatedAt() );
+
+        return fundingRewardItem.build();
+    }
+
+    protected List<FundingRewardItem> fundingRewardItemEntityListToFundingRewardItemList(List<FundingRewardItemEntity> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<FundingRewardItem> list1 = new ArrayList<FundingRewardItem>( list.size() );
+        for ( FundingRewardItemEntity fundingRewardItemEntity : list ) {
+            list1.add( fundingRewardItemEntityToFundingRewardItem( fundingRewardItemEntity ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingReward fundingRewardEntityToFundingReward(FundingRewardEntity fundingRewardEntity) {
+        if ( fundingRewardEntity == null ) {
+            return null;
+        }
+
+        FundingReward.FundingRewardBuilder fundingReward = FundingReward.builder();
+
+        fundingReward.id( fundingRewardEntity.getId() );
+        fundingReward.funding( fundingEntityToFunding( fundingRewardEntity.getFunding() ) );
+        fundingReward.isDelivery( fundingRewardEntity.getIsDelivery() );
+        fundingReward.rewardTitle( fundingRewardEntity.getRewardTitle() );
+        fundingReward.amount( fundingRewardEntity.getAmount() );
+        fundingReward.fundingRewardItems( fundingRewardItemEntityListToFundingRewardItemList( fundingRewardEntity.getFundingRewardItems() ) );
+        fundingReward.countLimit( fundingRewardEntity.getCountLimit() );
+        fundingReward.personalLimit( fundingRewardEntity.getPersonalLimit() );
+        fundingReward.expectDate( fundingRewardEntity.getExpectDate() );
+        fundingReward.createdAt( fundingRewardEntity.getCreatedAt() );
+        fundingReward.updatedAt( fundingRewardEntity.getUpdatedAt() );
+
+        return fundingReward.build();
+    }
+
+    protected SupportDelivery supportDeliveryEntityToSupportDelivery(SupportDeliveryEntity supportDeliveryEntity) {
+        if ( supportDeliveryEntity == null ) {
+            return null;
+        }
+
+        SupportDelivery.SupportDeliveryBuilder supportDelivery = SupportDelivery.builder();
+
+        supportDelivery.id( supportDeliveryEntity.getId() );
+        supportDelivery.support( supportEntityToSupport( supportDeliveryEntity.getSupport() ) );
+        supportDelivery.status( supportDeliveryEntity.getStatus() );
+        supportDelivery.shipmentName( supportDeliveryEntity.getShipmentName() );
+        supportDelivery.shipmentAt( supportDeliveryEntity.getShipmentAt() );
+        supportDelivery.trackingName( supportDeliveryEntity.getTrackingName() );
+        supportDelivery.trackingAt( supportDeliveryEntity.getTrackingAt() );
+        supportDelivery.createdAt( supportDeliveryEntity.getCreatedAt() );
+        supportDelivery.updatedAt( supportDeliveryEntity.getUpdatedAt() );
+
+        return supportDelivery.build();
+    }
+
+    protected Support supportEntityToSupport(SupportEntity supportEntity) {
+        if ( supportEntity == null ) {
+            return null;
+        }
+
+        Support.SupportBuilder support = Support.builder();
+
+        support.id( supportEntity.getId() );
+        support.member( memberEntityToMember( supportEntity.getMember() ) );
+        support.funding( fundingEntityToFunding( supportEntity.getFunding() ) );
+        support.reward( fundingRewardEntityToFundingReward( supportEntity.getReward() ) );
+        support.supportKey( supportEntity.getSupportKey() );
+        support.status( supportEntity.getStatus() );
+        support.supportDelivery( supportDeliveryEntityToSupportDelivery( supportEntity.getSupportDelivery() ) );
+        support.supportPayment( toSupportPayment( supportEntity.getSupportPayment() ) );
+        support.createdAt( supportEntity.getCreatedAt() );
+        support.createdBy( supportEntity.getCreatedBy() );
+        support.updatedAt( supportEntity.getUpdatedAt() );
+        support.updatedBy( supportEntity.getUpdatedBy() );
+
+        return support.build();
     }
 }

--- a/src/main/generated/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportPaymentPersistenceMapperImpl.java
+++ b/src/main/generated/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportPaymentPersistenceMapperImpl.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-17T20:12:32+0900",
+    date = "2024-03-24T20:52:32+0900",
     comments = "version: 1.5.5.Final, compiler: javac, environment: Java 17.0.9 (Oracle Corporation)"
 )
 @Component
@@ -45,6 +45,7 @@ public class SupportPaymentPersistenceMapperImpl implements SupportPaymentPersis
 
         supportPayment.supportId( supportPaymentEntitySupportId( supportPaymentEntity ) );
         supportPayment.memberPaymentMethodId( supportPaymentEntityMemberPaymentMethodId( supportPaymentEntity ) );
+        supportPayment.memberPaymentMethodKey( supportPaymentEntityMemberPaymentMethodPaymentMethodKey( supportPaymentEntity ) );
         supportPayment.id( supportPaymentEntity.getId() );
         supportPayment.status( supportPaymentEntity.getStatus() );
         supportPayment.amount( supportPaymentEntity.getAmount() );
@@ -75,6 +76,7 @@ public class SupportPaymentPersistenceMapperImpl implements SupportPaymentPersis
         MemberPaymentMethodEntity.MemberPaymentMethodEntityBuilder<?, ?> memberPaymentMethodEntity = MemberPaymentMethodEntity.builder();
 
         memberPaymentMethodEntity.id( supportPayment.getMemberPaymentMethodId() );
+        memberPaymentMethodEntity.paymentMethodKey( supportPayment.getMemberPaymentMethodKey() );
 
         return memberPaymentMethodEntity.build();
     }
@@ -107,5 +109,20 @@ public class SupportPaymentPersistenceMapperImpl implements SupportPaymentPersis
             return null;
         }
         return id;
+    }
+
+    private String supportPaymentEntityMemberPaymentMethodPaymentMethodKey(SupportPaymentEntity supportPaymentEntity) {
+        if ( supportPaymentEntity == null ) {
+            return null;
+        }
+        MemberPaymentMethodEntity memberPaymentMethod = supportPaymentEntity.getMemberPaymentMethod();
+        if ( memberPaymentMethod == null ) {
+            return null;
+        }
+        String paymentMethodKey = memberPaymentMethod.getPaymentMethodKey();
+        if ( paymentMethodKey == null ) {
+            return null;
+        }
+        return paymentMethodKey;
     }
 }

--- a/src/main/generated/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportPersistenceMapperImpl.java
+++ b/src/main/generated/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportPersistenceMapperImpl.java
@@ -1,20 +1,33 @@
 package com.flab.funding.infrastructure.adapters.output.persistence.mapper;
 
+import com.flab.funding.domain.model.Funding;
+import com.flab.funding.domain.model.FundingItem;
+import com.flab.funding.domain.model.FundingItemOption;
+import com.flab.funding.domain.model.FundingReward;
+import com.flab.funding.domain.model.FundingRewardItem;
+import com.flab.funding.domain.model.FundingTag;
+import com.flab.funding.domain.model.Member;
 import com.flab.funding.domain.model.Support;
 import com.flab.funding.domain.model.SupportDelivery;
 import com.flab.funding.domain.model.SupportPayment;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingItemEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingItemOptionEntity;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingRewardEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingRewardItemEntity;
+import com.flab.funding.infrastructure.adapters.output.persistence.entity.FundingTagEntity;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.MemberEntity;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.SupportDeliveryEntity;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.SupportEntity;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.SupportPaymentEntity;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.processing.Generated;
 import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-03-17T20:12:32+0900",
+    date = "2024-03-25T18:50:00+0900",
     comments = "version: 1.5.5.Final, compiler: javac, environment: Java 17.0.9 (Oracle Corporation)"
 )
 @Component
@@ -28,10 +41,10 @@ public class SupportPersistenceMapperImpl implements SupportPersistenceMapper {
 
         SupportEntity.SupportEntityBuilder supportEntity = SupportEntity.builder();
 
-        supportEntity.member( supportToMemberEntity( support ) );
-        supportEntity.funding( supportToFundingEntity( support ) );
-        supportEntity.reward( supportToFundingRewardEntity( support ) );
         supportEntity.id( support.getId() );
+        supportEntity.member( memberToMemberEntity( support.getMember() ) );
+        supportEntity.funding( fundingToFundingEntity( support.getFunding() ) );
+        supportEntity.reward( fundingRewardToFundingRewardEntity( support.getReward() ) );
         supportEntity.supportKey( support.getSupportKey() );
         supportEntity.status( support.getStatus() );
         supportEntity.supportDelivery( supportDeliveryToSupportDeliveryEntity( support.getSupportDelivery() ) );
@@ -52,10 +65,10 @@ public class SupportPersistenceMapperImpl implements SupportPersistenceMapper {
 
         Support.SupportBuilder support = Support.builder();
 
-        support.userId( supportEntityMemberId( supportEntity ) );
-        support.fundingId( supportEntityFundingId( supportEntity ) );
-        support.rewardId( supportEntityRewardId( supportEntity ) );
         support.id( supportEntity.getId() );
+        support.member( memberEntityToMember( supportEntity.getMember() ) );
+        support.funding( fundingEntityToFunding( supportEntity.getFunding() ) );
+        support.reward( fundingRewardEntityToFundingReward( supportEntity.getReward() ) );
         support.supportKey( supportEntity.getSupportKey() );
         support.status( supportEntity.getStatus() );
         support.supportDelivery( toSupportDelivery( supportEntity.getSupportDelivery() ) );
@@ -76,8 +89,8 @@ public class SupportPersistenceMapperImpl implements SupportPersistenceMapper {
 
         SupportDelivery.SupportDeliveryBuilder supportDelivery1 = SupportDelivery.builder();
 
-        supportDelivery1.supportKey( supportDeliverySupportSupportKey( supportDelivery ) );
         supportDelivery1.id( supportDelivery.getId() );
+        supportDelivery1.support( toSupport( supportDelivery.getSupport() ) );
         supportDelivery1.status( supportDelivery.getStatus() );
         supportDelivery1.shipmentName( supportDelivery.getShipmentName() );
         supportDelivery1.shipmentAt( supportDelivery.getShipmentAt() );
@@ -89,38 +102,187 @@ public class SupportPersistenceMapperImpl implements SupportPersistenceMapper {
         return supportDelivery1.build();
     }
 
-    protected MemberEntity supportToMemberEntity(Support support) {
-        if ( support == null ) {
+    protected MemberEntity memberToMemberEntity(Member member) {
+        if ( member == null ) {
             return null;
         }
 
         MemberEntity.MemberEntityBuilder memberEntity = MemberEntity.builder();
 
-        memberEntity.id( support.getUserId() );
+        memberEntity.id( member.getId() );
+        memberEntity.userKey( member.getUserKey() );
+        memberEntity.status( member.getStatus() );
+        memberEntity.linkType( member.getLinkType() );
+        memberEntity.email( member.getEmail() );
+        memberEntity.userName( member.getUserName() );
+        memberEntity.nickName( member.getNickName() );
+        memberEntity.phoneNumber( member.getPhoneNumber() );
+        memberEntity.gender( member.getGender() );
+        memberEntity.birthday( member.getBirthday() );
+        memberEntity.password( member.getPassword() );
+        memberEntity.lastLoginAt( member.getLastLoginAt() );
+        memberEntity.createdAt( member.getCreatedAt() );
+        memberEntity.updatedAt( member.getUpdatedAt() );
 
         return memberEntity.build();
     }
 
-    protected FundingEntity supportToFundingEntity(Support support) {
-        if ( support == null ) {
+    protected FundingTagEntity fundingTagToFundingTagEntity(FundingTag fundingTag) {
+        if ( fundingTag == null ) {
+            return null;
+        }
+
+        FundingTagEntity.FundingTagEntityBuilder fundingTagEntity = FundingTagEntity.builder();
+
+        fundingTagEntity.id( fundingTag.getId() );
+        fundingTagEntity.funding( fundingToFundingEntity( fundingTag.getFunding() ) );
+        fundingTagEntity.tag( fundingTag.getTag() );
+        fundingTagEntity.createdAt( fundingTag.getCreatedAt() );
+        fundingTagEntity.updatedAt( fundingTag.getUpdatedAt() );
+
+        return fundingTagEntity.build();
+    }
+
+    protected List<FundingTagEntity> fundingTagListToFundingTagEntityList(List<FundingTag> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<FundingTagEntity> list1 = new ArrayList<FundingTagEntity>( list.size() );
+        for ( FundingTag fundingTag : list ) {
+            list1.add( fundingTagToFundingTagEntity( fundingTag ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingEntity fundingToFundingEntity(Funding funding) {
+        if ( funding == null ) {
             return null;
         }
 
         FundingEntity.FundingEntityBuilder fundingEntity = FundingEntity.builder();
 
-        fundingEntity.id( support.getFundingId() );
+        fundingEntity.id( funding.getId() );
+        fundingEntity.fundingKey( funding.getFundingKey() );
+        fundingEntity.member( memberToMemberEntity( funding.getMember() ) );
+        fundingEntity.isAdult( funding.getIsAdult() );
+        fundingEntity.pricePlan( funding.getPricePlan() );
+        fundingEntity.category( funding.getCategory() );
+        fundingEntity.expectAmount( funding.getExpectAmount() );
+        fundingEntity.status( funding.getStatus() );
+        fundingEntity.title( funding.getTitle() );
+        fundingEntity.fundingDescription( funding.getFundingDescription() );
+        fundingEntity.fundingIntroduce( funding.getFundingIntroduce() );
+        fundingEntity.budgetDescription( funding.getBudgetDescription() );
+        fundingEntity.scheduleDescription( funding.getScheduleDescription() );
+        fundingEntity.teamDescription( funding.getTeamDescription() );
+        fundingEntity.rewardDescription( funding.getRewardDescription() );
+        fundingEntity.tags( fundingTagListToFundingTagEntityList( funding.getTags() ) );
+        fundingEntity.startAt( funding.getStartAt() );
+        fundingEntity.endAt( funding.getEndAt() );
+        fundingEntity.createdAt( funding.getCreatedAt() );
+        fundingEntity.createdBy( funding.getCreatedBy() );
+        fundingEntity.updatedAt( funding.getUpdatedAt() );
+        fundingEntity.updatedBy( funding.getUpdatedBy() );
 
         return fundingEntity.build();
     }
 
-    protected FundingRewardEntity supportToFundingRewardEntity(Support support) {
-        if ( support == null ) {
+    protected FundingItemOptionEntity fundingItemOptionToFundingItemOptionEntity(FundingItemOption fundingItemOption) {
+        if ( fundingItemOption == null ) {
+            return null;
+        }
+
+        FundingItemOptionEntity.FundingItemOptionEntityBuilder fundingItemOptionEntity = FundingItemOptionEntity.builder();
+
+        fundingItemOptionEntity.id( fundingItemOption.getId() );
+        fundingItemOptionEntity.fundingItem( fundingItemToFundingItemEntity( fundingItemOption.getFundingItem() ) );
+        fundingItemOptionEntity.createdAt( fundingItemOption.getCreatedAt() );
+        fundingItemOptionEntity.updatedAt( fundingItemOption.getUpdatedAt() );
+
+        return fundingItemOptionEntity.build();
+    }
+
+    protected List<FundingItemOptionEntity> fundingItemOptionListToFundingItemOptionEntityList(List<FundingItemOption> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<FundingItemOptionEntity> list1 = new ArrayList<FundingItemOptionEntity>( list.size() );
+        for ( FundingItemOption fundingItemOption : list ) {
+            list1.add( fundingItemOptionToFundingItemOptionEntity( fundingItemOption ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingItemEntity fundingItemToFundingItemEntity(FundingItem fundingItem) {
+        if ( fundingItem == null ) {
+            return null;
+        }
+
+        FundingItemEntity.FundingItemEntityBuilder fundingItemEntity = FundingItemEntity.builder();
+
+        fundingItemEntity.id( fundingItem.getId() );
+        fundingItemEntity.funding( fundingToFundingEntity( fundingItem.getFunding() ) );
+        fundingItemEntity.itemName( fundingItem.getItemName() );
+        fundingItemEntity.optionType( fundingItem.getOptionType() );
+        fundingItemEntity.fundingItemOptions( fundingItemOptionListToFundingItemOptionEntityList( fundingItem.getFundingItemOptions() ) );
+        fundingItemEntity.createdAt( fundingItem.getCreatedAt() );
+        fundingItemEntity.updatedAt( fundingItem.getUpdatedAt() );
+
+        return fundingItemEntity.build();
+    }
+
+    protected FundingRewardItemEntity fundingRewardItemToFundingRewardItemEntity(FundingRewardItem fundingRewardItem) {
+        if ( fundingRewardItem == null ) {
+            return null;
+        }
+
+        FundingRewardItemEntity.FundingRewardItemEntityBuilder fundingRewardItemEntity = FundingRewardItemEntity.builder();
+
+        fundingRewardItemEntity.id( fundingRewardItem.getId() );
+        fundingRewardItemEntity.funding( fundingToFundingEntity( fundingRewardItem.getFunding() ) );
+        fundingRewardItemEntity.fundingReward( fundingRewardToFundingRewardEntity( fundingRewardItem.getFundingReward() ) );
+        fundingRewardItemEntity.fundingItem( fundingItemToFundingItemEntity( fundingRewardItem.getFundingItem() ) );
+        fundingRewardItemEntity.createdAt( fundingRewardItem.getCreatedAt() );
+        fundingRewardItemEntity.updatedAt( fundingRewardItem.getUpdatedAt() );
+
+        return fundingRewardItemEntity.build();
+    }
+
+    protected List<FundingRewardItemEntity> fundingRewardItemListToFundingRewardItemEntityList(List<FundingRewardItem> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<FundingRewardItemEntity> list1 = new ArrayList<FundingRewardItemEntity>( list.size() );
+        for ( FundingRewardItem fundingRewardItem : list ) {
+            list1.add( fundingRewardItemToFundingRewardItemEntity( fundingRewardItem ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingRewardEntity fundingRewardToFundingRewardEntity(FundingReward fundingReward) {
+        if ( fundingReward == null ) {
             return null;
         }
 
         FundingRewardEntity.FundingRewardEntityBuilder fundingRewardEntity = FundingRewardEntity.builder();
 
-        fundingRewardEntity.id( support.getRewardId() );
+        fundingRewardEntity.id( fundingReward.getId() );
+        fundingRewardEntity.funding( fundingToFundingEntity( fundingReward.getFunding() ) );
+        fundingRewardEntity.isDelivery( fundingReward.getIsDelivery() );
+        fundingRewardEntity.rewardTitle( fundingReward.getRewardTitle() );
+        fundingRewardEntity.amount( fundingReward.getAmount() );
+        fundingRewardEntity.fundingRewardItems( fundingRewardItemListToFundingRewardItemEntityList( fundingReward.getFundingRewardItems() ) );
+        fundingRewardEntity.countLimit( fundingReward.getCountLimit() );
+        fundingRewardEntity.personalLimit( fundingReward.getPersonalLimit() );
+        fundingRewardEntity.expectDate( fundingReward.getExpectDate() );
+        fundingRewardEntity.createdAt( fundingReward.getCreatedAt() );
+        fundingRewardEntity.updatedAt( fundingReward.getUpdatedAt() );
 
         return fundingRewardEntity.build();
     }
@@ -133,6 +295,7 @@ public class SupportPersistenceMapperImpl implements SupportPersistenceMapper {
         SupportDeliveryEntity.SupportDeliveryEntityBuilder supportDeliveryEntity = SupportDeliveryEntity.builder();
 
         supportDeliveryEntity.id( supportDelivery.getId() );
+        supportDeliveryEntity.support( toSupportEntity( supportDelivery.getSupport() ) );
         supportDeliveryEntity.status( supportDelivery.getStatus() );
         supportDeliveryEntity.shipmentName( supportDelivery.getShipmentName() );
         supportDeliveryEntity.shipmentAt( supportDelivery.getShipmentAt() );
@@ -152,6 +315,7 @@ public class SupportPersistenceMapperImpl implements SupportPersistenceMapper {
         SupportPaymentEntity.SupportPaymentEntityBuilder supportPaymentEntity = SupportPaymentEntity.builder();
 
         supportPaymentEntity.id( supportPayment.getId() );
+        supportPaymentEntity.support( toSupportEntity( supportPayment.getSupport() ) );
         supportPaymentEntity.status( supportPayment.getStatus() );
         supportPaymentEntity.amount( supportPayment.getAmount() );
         supportPaymentEntity.paymentAt( supportPayment.getPaymentAt() );
@@ -161,49 +325,189 @@ public class SupportPersistenceMapperImpl implements SupportPersistenceMapper {
         return supportPaymentEntity.build();
     }
 
-    private Long supportEntityMemberId(SupportEntity supportEntity) {
-        if ( supportEntity == null ) {
+    protected Member memberEntityToMember(MemberEntity memberEntity) {
+        if ( memberEntity == null ) {
             return null;
         }
-        MemberEntity member = supportEntity.getMember();
-        if ( member == null ) {
-            return null;
-        }
-        Long id = member.getId();
-        if ( id == null ) {
-            return null;
-        }
-        return id;
+
+        Member.MemberBuilder member = Member.builder();
+
+        member.id( memberEntity.getId() );
+        member.userKey( memberEntity.getUserKey() );
+        member.status( memberEntity.getStatus() );
+        member.linkType( memberEntity.getLinkType() );
+        member.email( memberEntity.getEmail() );
+        member.userName( memberEntity.getUserName() );
+        member.nickName( memberEntity.getNickName() );
+        member.phoneNumber( memberEntity.getPhoneNumber() );
+        member.gender( memberEntity.getGender() );
+        member.birthday( memberEntity.getBirthday() );
+        member.password( memberEntity.getPassword() );
+        member.lastLoginAt( memberEntity.getLastLoginAt() );
+        member.createdAt( memberEntity.getCreatedAt() );
+        member.updatedAt( memberEntity.getUpdatedAt() );
+
+        return member.build();
     }
 
-    private Long supportEntityFundingId(SupportEntity supportEntity) {
-        if ( supportEntity == null ) {
+    protected FundingTag fundingTagEntityToFundingTag(FundingTagEntity fundingTagEntity) {
+        if ( fundingTagEntity == null ) {
             return null;
         }
-        FundingEntity funding = supportEntity.getFunding();
-        if ( funding == null ) {
-            return null;
-        }
-        Long id = funding.getId();
-        if ( id == null ) {
-            return null;
-        }
-        return id;
+
+        FundingTag.FundingTagBuilder fundingTag = FundingTag.builder();
+
+        fundingTag.id( fundingTagEntity.getId() );
+        fundingTag.funding( fundingEntityToFunding( fundingTagEntity.getFunding() ) );
+        fundingTag.tag( fundingTagEntity.getTag() );
+        fundingTag.createdAt( fundingTagEntity.getCreatedAt() );
+        fundingTag.updatedAt( fundingTagEntity.getUpdatedAt() );
+
+        return fundingTag.build();
     }
 
-    private Long supportEntityRewardId(SupportEntity supportEntity) {
-        if ( supportEntity == null ) {
+    protected List<FundingTag> fundingTagEntityListToFundingTagList(List<FundingTagEntity> list) {
+        if ( list == null ) {
             return null;
         }
-        FundingRewardEntity reward = supportEntity.getReward();
-        if ( reward == null ) {
+
+        List<FundingTag> list1 = new ArrayList<FundingTag>( list.size() );
+        for ( FundingTagEntity fundingTagEntity : list ) {
+            list1.add( fundingTagEntityToFundingTag( fundingTagEntity ) );
+        }
+
+        return list1;
+    }
+
+    protected Funding fundingEntityToFunding(FundingEntity fundingEntity) {
+        if ( fundingEntity == null ) {
             return null;
         }
-        Long id = reward.getId();
-        if ( id == null ) {
+
+        Funding.FundingBuilder funding = Funding.builder();
+
+        funding.id( fundingEntity.getId() );
+        funding.fundingKey( fundingEntity.getFundingKey() );
+        funding.member( memberEntityToMember( fundingEntity.getMember() ) );
+        funding.isAdult( fundingEntity.getIsAdult() );
+        funding.pricePlan( fundingEntity.getPricePlan() );
+        funding.category( fundingEntity.getCategory() );
+        funding.expectAmount( fundingEntity.getExpectAmount() );
+        funding.status( fundingEntity.getStatus() );
+        funding.title( fundingEntity.getTitle() );
+        funding.fundingDescription( fundingEntity.getFundingDescription() );
+        funding.fundingIntroduce( fundingEntity.getFundingIntroduce() );
+        funding.budgetDescription( fundingEntity.getBudgetDescription() );
+        funding.scheduleDescription( fundingEntity.getScheduleDescription() );
+        funding.teamDescription( fundingEntity.getTeamDescription() );
+        funding.rewardDescription( fundingEntity.getRewardDescription() );
+        funding.tags( fundingTagEntityListToFundingTagList( fundingEntity.getTags() ) );
+        funding.startAt( fundingEntity.getStartAt() );
+        funding.endAt( fundingEntity.getEndAt() );
+        funding.createdAt( fundingEntity.getCreatedAt() );
+        funding.createdBy( fundingEntity.getCreatedBy() );
+        funding.updatedAt( fundingEntity.getUpdatedAt() );
+        funding.updatedBy( fundingEntity.getUpdatedBy() );
+
+        return funding.build();
+    }
+
+    protected FundingItemOption fundingItemOptionEntityToFundingItemOption(FundingItemOptionEntity fundingItemOptionEntity) {
+        if ( fundingItemOptionEntity == null ) {
             return null;
         }
-        return id;
+
+        FundingItemOption.FundingItemOptionBuilder fundingItemOption = FundingItemOption.builder();
+
+        fundingItemOption.id( fundingItemOptionEntity.getId() );
+        fundingItemOption.fundingItem( fundingItemEntityToFundingItem( fundingItemOptionEntity.getFundingItem() ) );
+        fundingItemOption.createdAt( fundingItemOptionEntity.getCreatedAt() );
+        fundingItemOption.updatedAt( fundingItemOptionEntity.getUpdatedAt() );
+
+        return fundingItemOption.build();
+    }
+
+    protected List<FundingItemOption> fundingItemOptionEntityListToFundingItemOptionList(List<FundingItemOptionEntity> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<FundingItemOption> list1 = new ArrayList<FundingItemOption>( list.size() );
+        for ( FundingItemOptionEntity fundingItemOptionEntity : list ) {
+            list1.add( fundingItemOptionEntityToFundingItemOption( fundingItemOptionEntity ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingItem fundingItemEntityToFundingItem(FundingItemEntity fundingItemEntity) {
+        if ( fundingItemEntity == null ) {
+            return null;
+        }
+
+        FundingItem.FundingItemBuilder fundingItem = FundingItem.builder();
+
+        fundingItem.id( fundingItemEntity.getId() );
+        fundingItem.funding( fundingEntityToFunding( fundingItemEntity.getFunding() ) );
+        fundingItem.itemName( fundingItemEntity.getItemName() );
+        fundingItem.optionType( fundingItemEntity.getOptionType() );
+        fundingItem.fundingItemOptions( fundingItemOptionEntityListToFundingItemOptionList( fundingItemEntity.getFundingItemOptions() ) );
+        fundingItem.createdAt( fundingItemEntity.getCreatedAt() );
+        fundingItem.updatedAt( fundingItemEntity.getUpdatedAt() );
+
+        return fundingItem.build();
+    }
+
+    protected FundingRewardItem fundingRewardItemEntityToFundingRewardItem(FundingRewardItemEntity fundingRewardItemEntity) {
+        if ( fundingRewardItemEntity == null ) {
+            return null;
+        }
+
+        FundingRewardItem.FundingRewardItemBuilder fundingRewardItem = FundingRewardItem.builder();
+
+        fundingRewardItem.id( fundingRewardItemEntity.getId() );
+        fundingRewardItem.funding( fundingEntityToFunding( fundingRewardItemEntity.getFunding() ) );
+        fundingRewardItem.fundingReward( fundingRewardEntityToFundingReward( fundingRewardItemEntity.getFundingReward() ) );
+        fundingRewardItem.fundingItem( fundingItemEntityToFundingItem( fundingRewardItemEntity.getFundingItem() ) );
+        fundingRewardItem.createdAt( fundingRewardItemEntity.getCreatedAt() );
+        fundingRewardItem.updatedAt( fundingRewardItemEntity.getUpdatedAt() );
+
+        return fundingRewardItem.build();
+    }
+
+    protected List<FundingRewardItem> fundingRewardItemEntityListToFundingRewardItemList(List<FundingRewardItemEntity> list) {
+        if ( list == null ) {
+            return null;
+        }
+
+        List<FundingRewardItem> list1 = new ArrayList<FundingRewardItem>( list.size() );
+        for ( FundingRewardItemEntity fundingRewardItemEntity : list ) {
+            list1.add( fundingRewardItemEntityToFundingRewardItem( fundingRewardItemEntity ) );
+        }
+
+        return list1;
+    }
+
+    protected FundingReward fundingRewardEntityToFundingReward(FundingRewardEntity fundingRewardEntity) {
+        if ( fundingRewardEntity == null ) {
+            return null;
+        }
+
+        FundingReward.FundingRewardBuilder fundingReward = FundingReward.builder();
+
+        fundingReward.id( fundingRewardEntity.getId() );
+        fundingReward.funding( fundingEntityToFunding( fundingRewardEntity.getFunding() ) );
+        fundingReward.isDelivery( fundingRewardEntity.getIsDelivery() );
+        fundingReward.rewardTitle( fundingRewardEntity.getRewardTitle() );
+        fundingReward.amount( fundingRewardEntity.getAmount() );
+        fundingReward.fundingRewardItems( fundingRewardItemEntityListToFundingRewardItemList( fundingRewardEntity.getFundingRewardItems() ) );
+        fundingReward.countLimit( fundingRewardEntity.getCountLimit() );
+        fundingReward.personalLimit( fundingRewardEntity.getPersonalLimit() );
+        fundingReward.expectDate( fundingRewardEntity.getExpectDate() );
+        fundingReward.createdAt( fundingRewardEntity.getCreatedAt() );
+        fundingReward.updatedAt( fundingRewardEntity.getUpdatedAt() );
+
+        return fundingReward.build();
     }
 
     protected SupportPayment supportPaymentEntityToSupportPayment(SupportPaymentEntity supportPaymentEntity) {
@@ -214,6 +518,7 @@ public class SupportPersistenceMapperImpl implements SupportPersistenceMapper {
         SupportPayment.SupportPaymentBuilder supportPayment = SupportPayment.builder();
 
         supportPayment.id( supportPaymentEntity.getId() );
+        supportPayment.support( toSupport( supportPaymentEntity.getSupport() ) );
         supportPayment.status( supportPaymentEntity.getStatus() );
         supportPayment.amount( supportPaymentEntity.getAmount() );
         supportPayment.paymentAt( supportPaymentEntity.getPaymentAt() );
@@ -221,20 +526,5 @@ public class SupportPersistenceMapperImpl implements SupportPersistenceMapper {
         supportPayment.updatedAt( supportPaymentEntity.getUpdatedAt() );
 
         return supportPayment.build();
-    }
-
-    private String supportDeliverySupportSupportKey(SupportDeliveryEntity supportDeliveryEntity) {
-        if ( supportDeliveryEntity == null ) {
-            return null;
-        }
-        SupportEntity support = supportDeliveryEntity.getSupport();
-        if ( support == null ) {
-            return null;
-        }
-        String supportKey = support.getSupportKey();
-        if ( supportKey == null ) {
-            return null;
-        }
-        return supportKey;
     }
 }

--- a/src/main/java/com/flab/funding/application/ports/output/SupportPort.java
+++ b/src/main/java/com/flab/funding/application/ports/output/SupportPort.java
@@ -7,9 +7,9 @@ public interface SupportPort {
 
     Support saveSupport(Support support);
 
-    Support getSupportBySupportKey(String SupportKey);
+    Support getSupportRequest(String SupportKey);
 
-    SupportDelivery getSupportDeliveryBySupportKey(String supportKey);
+    SupportDelivery getSupportDeliveryRequest(String supportKey);
 
     SupportDelivery saveSupportDelivery(SupportDelivery supportDelivery);
 

--- a/src/main/java/com/flab/funding/domain/model/FundingCreator.java
+++ b/src/main/java/com/flab/funding/domain/model/FundingCreator.java
@@ -10,8 +10,7 @@ import java.time.LocalDateTime;
 public class FundingCreator {
 
     private Long id;
-    private Long fundingId;
-    private String fundingKey;
+    private Funding funding;
     private boolean isValid;
     private String businessNumber;
     private String representative;

--- a/src/main/java/com/flab/funding/domain/model/FundingItem.java
+++ b/src/main/java/com/flab/funding/domain/model/FundingItem.java
@@ -11,8 +11,7 @@ import java.util.List;
 public class FundingItem {
 
     private Long id;
-    private Long fundingId;
-    private String fundingKey;
+    private Funding funding;
     private String itemName;
     private FundingItemOptionType optionType;
     private List<FundingItemOption> fundingItemOptions;

--- a/src/main/java/com/flab/funding/domain/model/FundingItemOption.java
+++ b/src/main/java/com/flab/funding/domain/model/FundingItemOption.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 public class FundingItemOption {
 
     private Long id;
-    private Long fundingItemId;
+    private FundingItem fundingItem;
     private String option;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/flab/funding/domain/model/FundingReward.java
+++ b/src/main/java/com/flab/funding/domain/model/FundingReward.java
@@ -13,8 +13,7 @@ import java.util.List;
 public class FundingReward {
 
     private Long id;
-    private Long fundingId;
-    private String fundingKey;
+    private Funding funding;
     private boolean isDelivery;
     private String rewardTitle;
     private BigInteger amount;

--- a/src/main/java/com/flab/funding/domain/model/FundingRewardItem.java
+++ b/src/main/java/com/flab/funding/domain/model/FundingRewardItem.java
@@ -10,9 +10,9 @@ import java.time.LocalDateTime;
 public class FundingRewardItem {
 
     private Long id;
-    private Long fundingId;
-    private Long fundingRewardId;
-    private Long fundingItemId;
+    private Funding funding;
+    private FundingReward fundingReward;
+    private FundingItem fundingItem;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/flab/funding/domain/model/FundingTag.java
+++ b/src/main/java/com/flab/funding/domain/model/FundingTag.java
@@ -10,8 +10,7 @@ import java.time.LocalDateTime;
 public class FundingTag {
 
     private Long id;
-    private Long fundingId;
-    private String fundingKey;
+    private Funding funding;
     private String tag;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/flab/funding/domain/model/Support.java
+++ b/src/main/java/com/flab/funding/domain/model/Support.java
@@ -11,11 +11,9 @@ import java.util.UUID;
 public class Support {
 
     private Long id;
-    private Long userId;
-    private String userKey;
-    private Long fundingId;
-    private String fundingKey;
-    private Long rewardId;
+    private Member member;
+    private Funding funding;
+    private FundingReward reward;
     private String supportKey;
     private SupportStatus status;
     private SupportDelivery supportDelivery;

--- a/src/main/java/com/flab/funding/domain/model/SupportDelivery.java
+++ b/src/main/java/com/flab/funding/domain/model/SupportDelivery.java
@@ -10,10 +10,8 @@ import java.time.LocalDateTime;
 public class SupportDelivery {
 
     private Long id;
-    private Long supportId;
-    private String supportKey;
-    private Long memberDeliveryAddressId;
-    private String memberDeliveryAddressKey;
+    private Support support;
+    private DeliveryAddress deliveryAddress;
     private SupportDeliveryStatus status;
     private String shipmentName;
     private LocalDateTime shipmentAt;

--- a/src/main/java/com/flab/funding/domain/model/SupportPayment.java
+++ b/src/main/java/com/flab/funding/domain/model/SupportPayment.java
@@ -11,9 +11,8 @@ import java.time.LocalDateTime;
 public class SupportPayment {
 
     private Long id;
-    private Long supportId;
-    private Long memberPaymentMethodId;
-    private String memberPaymentMethodKey;
+    private Support support;
+    private PaymentMethod paymentMethod;
     private SupportPaymentStatus status;
     private BigInteger amount;
     private LocalDateTime paymentAt;

--- a/src/main/java/com/flab/funding/domain/service/SupportService.java
+++ b/src/main/java/com/flab/funding/domain/service/SupportService.java
@@ -24,24 +24,24 @@ public class SupportService implements RegisterSupportUseCase, SupportDeliveryUs
 
     @Override
     public Support getSupportBySupportKey(String supportKey) {
-        return supportPort.getSupportBySupportKey(supportKey);
+        return supportPort.getSupportRequest(supportKey);
     }
 
     @Override
     public SupportDelivery shippedOut(String supportKey) {
-        SupportDelivery findSupportDelivery = supportPort.getSupportDeliveryBySupportKey(supportKey);
+        SupportDelivery findSupportDelivery = supportPort.getSupportDeliveryRequest(supportKey);
         return supportPort.saveSupportDelivery(findSupportDelivery.shippedOut());
     }
 
     @Override
     public SupportDelivery outForDelivery(String supportKey) {
-        SupportDelivery findSupportDelivery = supportPort.getSupportDeliveryBySupportKey(supportKey);
+        SupportDelivery findSupportDelivery = supportPort.getSupportDeliveryRequest(supportKey);
         return supportPort.saveSupportDelivery(findSupportDelivery.inDelivery());
     }
 
     @Override
     public SupportDelivery deliveryComplete(String supportKey) {
-        SupportDelivery findSupportDelivery = supportPort.getSupportDeliveryBySupportKey(supportKey);
+        SupportDelivery findSupportDelivery = supportPort.getSupportDeliveryRequest(supportKey);
         return supportPort.saveSupportDelivery(findSupportDelivery.complete());
     }
 

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/DefaultMethodToMapper.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/DefaultMethodToMapper.java
@@ -1,0 +1,32 @@
+package com.flab.funding.infrastructure.adapters.input.mapper;
+
+import com.flab.funding.domain.model.Funding;
+import com.flab.funding.domain.model.FundingReward;
+import com.flab.funding.domain.model.Member;
+
+public interface DefaultMethodToMapper {
+
+    default Member toMember(String userKey) {
+        if (userKey == null) {
+            return null;
+        }
+
+        return Member.builder().userKey(userKey).build();
+    }
+
+    default Funding toFunding(String fundingKey) {
+        if (fundingKey == null) {
+            return null;
+        }
+
+        return Funding.builder().fundingKey(fundingKey).build();
+    }
+
+    default FundingReward toReward(Long rewardId) {
+        if (rewardId == null) {
+            return null;
+        }
+
+        return FundingReward.builder().id(rewardId).build();
+    }
+}

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/FundingMapper.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/FundingMapper.java
@@ -11,12 +11,11 @@ import com.flab.funding.infrastructure.adapters.input.data.request.FundingReward
 import com.flab.funding.infrastructure.adapters.input.data.response.*;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
-public interface FundingMapper {
+public interface FundingMapper extends DefaultMethodToMapper {
 
     FundingMapper INSTANCE = Mappers.getMapper(FundingMapper.class);
 
@@ -26,13 +25,10 @@ public interface FundingMapper {
 
     FundingInfoResponse toFundingInfoResponse(Funding funding);
 
-    @Mapping(source = "fundingKey", target = "funding", qualifiedByName = "toFunding")
     FundingCreator toFundingCreator(FundingCreatorRegisterRequest fundingCreatorRegisterRequest);
 
-    @Mapping(source = "fundingKey", target = "funding", qualifiedByName = "toFunding")
     FundingReward toFundingReward(FundingRewardRegisterRequest fundingRewardRegisterRequest);
 
-    @Mapping(source = "fundingKey", target = "funding", qualifiedByName = "toFunding")
     FundingItem toFundingItem(FundingItemRegisterRequest fundingItemRegisterRequest);
 
     @Mapping(source = "funding.fundingKey", target = "fundingKey")
@@ -43,13 +39,4 @@ public interface FundingMapper {
 
     @Mapping(source = "funding.fundingKey", target = "fundingKey")
     FundingRewardInfoResponse toFundingRewardInfoResponse(FundingReward fundingReward);
-
-    @Named("toFunding")
-    default Funding toFunding(String value) {
-        if (value == null) {
-            return null;
-        }
-
-        return Funding.builder().fundingKey(value).build();
-    }
 }

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/FundingMapper.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/FundingMapper.java
@@ -10,6 +10,8 @@ import com.flab.funding.infrastructure.adapters.input.data.request.FundingRegist
 import com.flab.funding.infrastructure.adapters.input.data.request.FundingRewardRegisterRequest;
 import com.flab.funding.infrastructure.adapters.input.data.response.*;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
@@ -24,15 +26,30 @@ public interface FundingMapper {
 
     FundingInfoResponse toFundingInfoResponse(Funding funding);
 
+    @Mapping(source = "fundingKey", target = "funding", qualifiedByName = "toFunding")
     FundingCreator toFundingCreator(FundingCreatorRegisterRequest fundingCreatorRegisterRequest);
 
+    @Mapping(source = "fundingKey", target = "funding", qualifiedByName = "toFunding")
     FundingReward toFundingReward(FundingRewardRegisterRequest fundingRewardRegisterRequest);
 
+    @Mapping(source = "fundingKey", target = "funding", qualifiedByName = "toFunding")
     FundingItem toFundingItem(FundingItemRegisterRequest fundingItemRegisterRequest);
 
+    @Mapping(source = "funding.fundingKey", target = "fundingKey")
     FundingCreatorInfoResponse toFundingCreatorInfoResponse(FundingCreator fundingCreator);
 
+    @Mapping(source = "funding.fundingKey", target = "fundingKey")
     FundingItemInfoResponse toFundingItemInfoResponse(FundingItem fundingItem);
 
+    @Mapping(source = "funding.fundingKey", target = "fundingKey")
     FundingRewardInfoResponse toFundingRewardInfoResponse(FundingReward fundingReward);
+
+    @Named("toFunding")
+    default Funding toFunding(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        return Funding.builder().fundingKey(value).build();
+    }
 }

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/MemberDeliveryAddressMapper.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/MemberDeliveryAddressMapper.java
@@ -1,31 +1,20 @@
 package com.flab.funding.infrastructure.adapters.input.mapper;
 
 import com.flab.funding.domain.model.DeliveryAddress;
-import com.flab.funding.domain.model.Member;
 import com.flab.funding.infrastructure.adapters.input.data.request.MemberDeliveryAddressRegisterRequest;
 import com.flab.funding.infrastructure.adapters.input.data.response.MemberDeliveryAddressRegisterResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
-public interface MemberDeliveryAddressMapper {
+public interface MemberDeliveryAddressMapper extends DefaultMethodToMapper{
+
     MemberDeliveryAddressMapper INSTANCE = Mappers.getMapper(MemberDeliveryAddressMapper.class);
 
-    @Mapping(source = "userKey", target = "member", qualifiedByName = "toMember")
     DeliveryAddress toDeliveryAddress(MemberDeliveryAddressRegisterRequest deliveryAddressRegisterRequest);
 
     @Mapping(source = "member.userKey", target = "userKey")
     MemberDeliveryAddressRegisterResponse toMemberDeliveryAddressRegisterResponse(DeliveryAddress deliveryAddress);
-
-    @Named("toMember")
-    default Member toMember(String value) {
-        if (value == null) {
-            return null;
-        }
-
-        return Member.builder().userKey(value).build();
-    }
 }

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/MemberPaymentMethodMapper.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/MemberPaymentMethodMapper.java
@@ -1,32 +1,20 @@
 package com.flab.funding.infrastructure.adapters.input.mapper;
 
-import com.flab.funding.domain.model.Member;
 import com.flab.funding.domain.model.PaymentMethod;
 import com.flab.funding.infrastructure.adapters.input.data.request.MemberPaymentMethodRegisterRequest;
 import com.flab.funding.infrastructure.adapters.input.data.response.MemberPaymentMethodRegisterResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
-public interface MemberPaymentMethodMapper {
+public interface MemberPaymentMethodMapper extends DefaultMethodToMapper{
 
     MemberPaymentMethodMapper INSTANCE = Mappers.getMapper(MemberPaymentMethodMapper.class);
 
-    @Mapping(source = "userKey", target = "member", qualifiedByName = "toMember")
     PaymentMethod toPaymentMethod(MemberPaymentMethodRegisterRequest paymentMethodRegisterRequest);
 
     @Mapping(source = "member.userKey", target = "userKey")
     MemberPaymentMethodRegisterResponse toMemberPaymentMethodRegisterResponse(PaymentMethod paymentMethod);
-
-    @Named("toMember")
-    default Member toMember(String value) {
-        if (value == null) {
-            return null;
-        }
-
-        return Member.builder().userKey(value).build();
-    }
 }

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/SupportMapper.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/SupportMapper.java
@@ -10,7 +10,7 @@ import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
-public interface SupportMapper {
+public interface SupportMapper extends DefaultMethodToMapper {
 
     SupportMapper INSTANCE = Mappers.getMapper(SupportMapper.class);
 

--- a/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/SupportPersistenceAdapter.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/SupportPersistenceAdapter.java
@@ -23,7 +23,7 @@ public class SupportPersistenceAdapter implements SupportPort {
     }
 
     @Override
-    public Support getSupportBySupportKey(String SupportKey) {
+    public Support getSupportRequest(String SupportKey) {
         SupportEntity findSupportEntity
                 = supportRepository.getSupportBySupportKey(SupportKey)
                     .orElse(SupportEntity.builder().build());
@@ -39,7 +39,7 @@ public class SupportPersistenceAdapter implements SupportPort {
     }
 
     @Override
-    public SupportDelivery getSupportDeliveryBySupportKey(String supportKey) {
+    public SupportDelivery getSupportDeliveryRequest(String supportKey) {
         SupportDeliveryEntity findSupportDeliveryEntity
                 = supportRepository.getSupportDeliveryBySupportKey(supportKey)
                     .orElse(SupportDeliveryEntity.builder().build());

--- a/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/mapper/FundingPersistenceMapper.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/mapper/FundingPersistenceMapper.java
@@ -3,7 +3,6 @@ package com.flab.funding.infrastructure.adapters.output.persistence.mapper;
 import com.flab.funding.domain.model.*;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.*;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
@@ -16,36 +15,19 @@ public interface FundingPersistenceMapper {
 
     Funding toFunding(FundingEntity fundingEntity);
 
-    @Mapping(source = "fundingKey", target = "funding.fundingKey")
     FundingCreatorEntity toFundingCreatorEntity(FundingCreator fundingCreator);
 
-    @Mapping(source = "funding.id", target = "fundingId")
-    @Mapping(source = "funding.fundingKey", target = "fundingKey")
     FundingCreator toFundingCreator(FundingCreatorEntity fundingCreatorEntity);
 
-    @Mapping(source = "fundingId", target = "funding.id")
-    @Mapping(source = "fundingKey", target = "funding.fundingKey")
     FundingItemEntity toFundingItemEntity(FundingItem fundingItem);
 
-    @Mapping(source = "funding.id", target = "fundingId")
-    @Mapping(source = "funding.fundingKey", target = "fundingKey")
     FundingItem toFundingItem(FundingItemEntity fundingItemEntity);
 
-    @Mapping(source = "fundingId", target = "funding.id")
-    @Mapping(source = "fundingKey", target = "funding.fundingKey")
     FundingRewardEntity toFundingRewardEntity(FundingReward fundingReward);
 
-    @Mapping(source = "funding.id", target = "fundingId")
-    @Mapping(source = "funding.fundingKey", target = "fundingKey")
     FundingReward toFundingReward(FundingRewardEntity fundingRewardEntity);
 
-    @Mapping(source = "fundingId", target = "funding.id")
-    @Mapping(source = "fundingRewardId", target = "fundingReward.id")
-    @Mapping(source = "fundingItemId", target = "fundingItem.id")
     FundingRewardItemEntity toFundingRewardItemEntity(FundingRewardItem fundingRewardItem);
 
-    @Mapping(source = "funding.id", target = "fundingId")
-    @Mapping(source = "fundingReward.id", target = "fundingRewardId")
-    @Mapping(source = "fundingItem.id", target = "fundingItemId")
     FundingRewardItem toFundingRewardItem(FundingRewardItemEntity fundingRewardItemEntity);
 }

--- a/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportDeliveryPersistenceMapper.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportDeliveryPersistenceMapper.java
@@ -3,22 +3,15 @@ package com.flab.funding.infrastructure.adapters.output.persistence.mapper;
 import com.flab.funding.domain.model.SupportDelivery;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.SupportDeliveryEntity;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface SupportDeliveryPersistenceMapper {
 
     SupportDeliveryPersistenceMapper INSTANCE = Mappers.getMapper(SupportDeliveryPersistenceMapper.class);
 
-    @Mapping(source = "supportId", target = "support.id")
-    @Mapping(source = "memberDeliveryAddressId", target = "memberDeliveryAddress.id")
-    @Mapping(source = "memberDeliveryAddressKey", target = "memberDeliveryAddress.deliveryAddressKey")
     SupportDeliveryEntity SupportDeliveryEntity(SupportDelivery supportDelivery);
 
-    @Mapping(source = "support.id", target = "supportId")
-    @Mapping(source = "support.supportKey", target = "supportKey")
-    @Mapping(source = "memberDeliveryAddress.id", target = "memberDeliveryAddressId")
-    @Mapping(source = "memberDeliveryAddress.deliveryAddressKey", target = "memberDeliveryAddressKey")
     SupportDelivery toSupportDelivery(SupportDeliveryEntity supportDeliveryEntity);
 }

--- a/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportPaymentPersistenceMapper.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportPaymentPersistenceMapper.java
@@ -3,21 +3,15 @@ package com.flab.funding.infrastructure.adapters.output.persistence.mapper;
 import com.flab.funding.domain.model.SupportPayment;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.SupportPaymentEntity;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface SupportPaymentPersistenceMapper {
 
     SupportPaymentPersistenceMapper INSTANCE = Mappers.getMapper(SupportPaymentPersistenceMapper.class);
 
-    @Mapping(source = "supportId", target = "support.id")
-    @Mapping(source = "memberPaymentMethodId", target = "memberPaymentMethod.id")
-    @Mapping(source = "memberPaymentMethodKey", target = "memberPaymentMethod.paymentMethodKey")
     SupportPaymentEntity toSupportPaymentEntity(SupportPayment supportPayment);
 
-    @Mapping(source = "support.id", target = "supportId")
-    @Mapping(source = "memberPaymentMethod.id", target = "memberPaymentMethodId")
-    @Mapping(source = "memberPaymentMethod.paymentMethodKey", target = "memberPaymentMethodKey")
     SupportPayment toSupportPayment(SupportPaymentEntity supportPaymentEntity);
 }

--- a/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportPersistenceMapper.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/mapper/SupportPersistenceMapper.java
@@ -5,7 +5,6 @@ import com.flab.funding.domain.model.SupportDelivery;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.SupportDeliveryEntity;
 import com.flab.funding.infrastructure.adapters.output.persistence.entity.SupportEntity;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
@@ -14,16 +13,9 @@ public interface SupportPersistenceMapper {
 
     SupportPersistenceMapper INSTANCE = Mappers.getMapper(SupportPersistenceMapper.class);
 
-    @Mapping(source = "userId", target = "member.id")
-    @Mapping(source = "fundingId", target = "funding.id")
-    @Mapping(source = "rewardId", target = "reward.id")
     SupportEntity toSupportEntity(Support support);
 
-    @Mapping(source = "member.id", target = "userId")
-    @Mapping(source = "funding.id", target = "fundingId")
-    @Mapping(source = "reward.id", target = "rewardId")
     Support toSupport(SupportEntity supportEntity);
 
-    @Mapping(source = "support.supportKey", target = "supportKey")
     SupportDelivery toSupportDelivery(SupportDeliveryEntity supportDelivery);
 }

--- a/src/test/java/com/flab/funding/rest/FundingRestAdapterTest.java
+++ b/src/test/java/com/flab/funding/rest/FundingRestAdapterTest.java
@@ -217,7 +217,7 @@ public class FundingRestAdapterTest {
                 .build();
 
         FundingCreator response = FundingCreator.builder()
-                .fundingKey("FF-0001")
+                .funding(Funding.builder().fundingKey("FF-0001").build())
                 .isValid(true)
                 .businessNumber("12345678")
                 .representative("홍길동")
@@ -276,7 +276,7 @@ public class FundingRestAdapterTest {
 
 
         FundingItem response = FundingItem.builder()
-                .fundingKey("FF-0001")
+                .funding(Funding.builder().fundingKey("FF-0001").build())
                 .itemName("은 귀걸이")
                 .optionType(FundingItemOptionType.NONE)
                 .fundingItemOptions(responseItemOptions)
@@ -345,7 +345,7 @@ public class FundingRestAdapterTest {
         responseRewardItems.add(createResponseRewardItem(3L));
 
         FundingReward response = FundingReward.builder()
-                .fundingKey("FF-0001")
+                .funding(Funding.builder().fundingKey("FF-0001").build())
                 .isDelivery(true)
                 .rewardTitle("귀걸이 세트")
                 .amount(BigInteger.valueOf(15000))
@@ -398,7 +398,7 @@ public class FundingRestAdapterTest {
 
     private FundingRewardItem createResponseRewardItem(Long fundingItemId) {
         return FundingRewardItem.builder()
-                .fundingItemId(fundingItemId)
+                .fundingItem(FundingItem.builder().id(fundingItemId).build())
                 .build();
     }
 }

--- a/src/test/java/com/flab/funding/rest/FundingRestAdapterTest.java
+++ b/src/test/java/com/flab/funding/rest/FundingRestAdapterTest.java
@@ -217,7 +217,7 @@ public class FundingRestAdapterTest {
                 .build();
 
         FundingCreator response = FundingCreator.builder()
-                .funding(Funding.builder().fundingKey("FF-0001").build())
+                .funding(getFundingRequest())
                 .isValid(true)
                 .businessNumber("12345678")
                 .representative("홍길동")
@@ -251,6 +251,12 @@ public class FundingRestAdapterTest {
                         )));
     }
 
+    private Funding getFundingRequest() {
+        return Funding.builder()
+                .fundingKey("FF-0001")
+                .build();
+    }
+
     @Test
     void makeFundingItem() throws Exception {
 
@@ -276,7 +282,7 @@ public class FundingRestAdapterTest {
 
 
         FundingItem response = FundingItem.builder()
-                .funding(Funding.builder().fundingKey("FF-0001").build())
+                .funding(getFundingRequest())
                 .itemName("은 귀걸이")
                 .optionType(FundingItemOptionType.NONE)
                 .fundingItemOptions(responseItemOptions)
@@ -345,7 +351,7 @@ public class FundingRestAdapterTest {
         responseRewardItems.add(createResponseRewardItem(3L));
 
         FundingReward response = FundingReward.builder()
-                .funding(Funding.builder().fundingKey("FF-0001").build())
+                .funding(getFundingRequest())
                 .isDelivery(true)
                 .rewardTitle("귀걸이 세트")
                 .amount(BigInteger.valueOf(15000))

--- a/src/test/java/com/flab/funding/rest/SupportRestAdapterTest.java
+++ b/src/test/java/com/flab/funding/rest/SupportRestAdapterTest.java
@@ -107,7 +107,7 @@ public class SupportRestAdapterTest {
         String request = "SS-0001";
 
         SupportDelivery response = SupportDelivery.builder()
-                .supportKey("SS-0001")
+                .support(getSupportRequest())
                 .status(SupportDeliveryStatus.SHIPPED)
                 .build();
 
@@ -127,13 +127,19 @@ public class SupportRestAdapterTest {
                         )));
     }
 
+    private Support getSupportRequest() {
+        return Support.builder()
+                .supportKey("SS-0001")
+                .build();
+    }
+
     @Test
     public void inDelivery() throws Exception {
         //given
         String request = "SS-0001";
 
         SupportDelivery response = SupportDelivery.builder()
-                .supportKey("SS-0001")
+                .support(getSupportRequest())
                 .status(SupportDeliveryStatus.IN_DELIVERY)
                 .build();
 
@@ -160,7 +166,7 @@ public class SupportRestAdapterTest {
         String request = "SS-0001";
 
         SupportDelivery response = SupportDelivery.builder()
-                .supportKey("SS-0001")
+                .support(getSupportRequest())
                 .status(SupportDeliveryStatus.COMPLETE)
                 .build();
 

--- a/src/test/java/com/flab/funding/service/FundingServiceTest.java
+++ b/src/test/java/com/flab/funding/service/FundingServiceTest.java
@@ -125,11 +125,11 @@ public class FundingServiceTest {
 
         //when
         FundingCreator savedFundingCreator = fundingService.registerFundingCreator(fundingCreator);
-        FundingCreator findFundingCreator = fundingService.getFundingCreatorByFundingKey(savedFundingCreator.getFundingKey());
+        FundingCreator findFundingCreator = fundingService.getFundingCreatorByFundingKey(savedFundingCreator.getFunding().getFundingKey());
 
         //then
         assertEquals(savedFundingCreator.getId(), findFundingCreator.getId());
-        assertEquals(savedFundingCreator.getFundingKey(), findFundingCreator.getFundingKey());
+        assertEquals(savedFundingCreator.getFunding(), findFundingCreator.getFunding());
         assertEquals(savedFundingCreator.getIsValid(), findFundingCreator.getIsValid());
         assertEquals(savedFundingCreator.getBusinessNumber(), findFundingCreator.getBusinessNumber());
         assertEquals(savedFundingCreator.getRepresentative(), findFundingCreator.getRepresentative());
@@ -138,12 +138,16 @@ public class FundingServiceTest {
 
     private FundingCreator getFundingCreator() {
         return FundingCreator.builder()
-                .fundingKey("FF-0001")
+                .funding(getFundingByFundingKey())
                 .isValid(true)
                 .businessNumber("12345678")
                 .representative("홍길동")
                 .introduce("안녕하세요, 개인 사업자 홍길동입니다.")
                 .build();
+    }
+
+    private Funding getFundingByFundingKey() {
+        return Funding.builder().fundingKey("FF-0001").build();
     }
 
     @Test
@@ -160,11 +164,11 @@ public class FundingServiceTest {
 
         //when
         FundingItem savedFundingItem = fundingService.makeFundingItem(fundingItem);
-        FundingItem findFundingItem = fundingService.getFundingItemByFundingKey(savedFundingItem.getFundingKey());
+        FundingItem findFundingItem = fundingService.getFundingItemByFundingKey(savedFundingItem.getFunding().getFundingKey());
 
         //then
         assertEquals(savedFundingItem.getId(), findFundingItem.getId());
-        assertEquals(savedFundingItem.getFundingKey(), findFundingItem.getFundingKey());
+        assertEquals(savedFundingItem.getFunding(), findFundingItem.getFunding());
         assertEquals(savedFundingItem.getItemName(), findFundingItem.getItemName());
         assertEquals(savedFundingItem.getOptionType(), findFundingItem.getOptionType());
         assertIterableEquals(savedFundingItem.getFundingItemOptions(), findFundingItem.getFundingItemOptions());
@@ -172,7 +176,7 @@ public class FundingServiceTest {
 
     private FundingItem getFundingItem() {
         return FundingItem.builder()
-                .fundingKey("FF-0001")
+                .funding(getFundingByFundingKey())
                 .itemName("은 귀걸이")
                 .optionType(FundingItemOptionType.NONE)
                 .fundingItemOptions(getFundingItemOptions())
@@ -206,11 +210,11 @@ public class FundingServiceTest {
 
         //when
         FundingReward savedFundingReward = fundingService.makeFundingReward(fundingReward);
-        FundingReward findFundingReward = fundingService.getFundingRewardByFundingKey(savedFundingReward.getFundingKey());
+        FundingReward findFundingReward = fundingService.getFundingRewardByFundingKey(savedFundingReward.getFunding().getFundingKey());
 
         //then
         assertEquals(savedFundingReward.getId(), findFundingReward.getId());
-        assertEquals(savedFundingReward.getFundingKey(), findFundingReward.getFundingKey());
+        assertEquals(savedFundingReward.getFunding(), findFundingReward.getFunding());
         assertEquals(savedFundingReward.getIsDelivery(), findFundingReward.getIsDelivery());
         assertEquals(savedFundingReward.getRewardTitle(), findFundingReward.getRewardTitle());
         assertEquals(savedFundingReward.getAmount(), findFundingReward.getAmount());
@@ -223,7 +227,7 @@ public class FundingServiceTest {
 
     private FundingReward getFundingReward() {
         return FundingReward.builder()
-                .fundingKey("FF-0001")
+                .funding(getFundingByFundingKey())
                 .isDelivery(true)
                 .rewardTitle("귀걸이 세트")
                 .amount(BigInteger.valueOf(15000))
@@ -244,7 +248,7 @@ public class FundingServiceTest {
 
     private FundingRewardItem createRewardItem(Long fundingItemId) {
         return FundingRewardItem.builder()
-                .fundingItemId(fundingItemId)
+                .fundingItem(FundingItem.builder().id(fundingItemId).build())
                 .build();
     }
     

--- a/src/test/java/com/flab/funding/service/FundingServiceTest.java
+++ b/src/test/java/com/flab/funding/service/FundingServiceTest.java
@@ -138,7 +138,7 @@ public class FundingServiceTest {
 
     private FundingCreator getFundingCreator() {
         return FundingCreator.builder()
-                .funding(getFundingByFundingKey())
+                .funding(getFundingRequest())
                 .isValid(true)
                 .businessNumber("12345678")
                 .representative("홍길동")
@@ -146,7 +146,7 @@ public class FundingServiceTest {
                 .build();
     }
 
-    private Funding getFundingByFundingKey() {
+    private Funding getFundingRequest() {
         return Funding.builder().fundingKey("FF-0001").build();
     }
 
@@ -176,7 +176,7 @@ public class FundingServiceTest {
 
     private FundingItem getFundingItem() {
         return FundingItem.builder()
-                .funding(getFundingByFundingKey())
+                .funding(getFundingRequest())
                 .itemName("은 귀걸이")
                 .optionType(FundingItemOptionType.NONE)
                 .fundingItemOptions(getFundingItemOptions())
@@ -227,7 +227,7 @@ public class FundingServiceTest {
 
     private FundingReward getFundingReward() {
         return FundingReward.builder()
-                .funding(getFundingByFundingKey())
+                .funding(getFundingRequest())
                 .isDelivery(true)
                 .rewardTitle("귀걸이 세트")
                 .amount(BigInteger.valueOf(15000))

--- a/src/test/java/com/flab/funding/service/SupportServiceTest.java
+++ b/src/test/java/com/flab/funding/service/SupportServiceTest.java
@@ -33,7 +33,7 @@ public class SupportServiceTest {
         given(supportPort.saveSupport(any(Support.class)))
                 .willReturn(support);
 
-        given(supportPort.getSupportBySupportKey(any()))
+        given(supportPort.getSupportRequest(any()))
                 .willReturn(support);
 
         //when
@@ -43,9 +43,9 @@ public class SupportServiceTest {
         //then
         assertNotNull(savedSupport.getSupportKey());
         assertEquals(savedSupport.getId(), findSupport.getId());
-        assertEquals(savedSupport.getUserKey(), findSupport.getUserKey());
-        assertEquals(savedSupport.getFundingKey(), findSupport.getFundingKey());
-        assertEquals(savedSupport.getRewardId(), findSupport.getRewardId());
+        assertEquals(savedSupport.getMember().getUserKey(), findSupport.getMember().getUserKey());
+        assertEquals(savedSupport.getFunding().getFundingKey(), findSupport.getFunding().getFundingKey());
+        assertEquals(savedSupport.getReward().getId(), findSupport.getReward().getId());
         assertEquals(savedSupport.getSupportKey(), findSupport.getSupportKey());
         assertEquals(savedSupport.getStatus(), SupportStatus.RESERVATION);
         assertEquals(savedSupport.getStatus(), findSupport.getStatus());
@@ -56,24 +56,60 @@ public class SupportServiceTest {
 
     private Support getSupport() {
         return Support.builder()
-                .userKey("MM-0001")
-                .fundingKey("FF-0001")
-                .rewardId(1L)
+                .member(getMemberRequest())
+                .funding(getFundingRequest())
+                .reward(getRewardRequest())
                 .supportDelivery(getSupportDelivery())
                 .supportPayment(getSupportPayment())
                 .build();
     }
 
+    private Member getMemberRequest() {
+        return Member.builder()
+                .userKey("MM-0001")
+                .build();
+    }
+
+    private Funding getFundingRequest() {
+        return Funding.builder()
+                .fundingKey("FF-0001")
+                .build();
+    }
+
+    private FundingReward getRewardRequest() {
+        return FundingReward.builder()
+                .id(1L)
+                .build();
+    }
+
     private SupportPayment getSupportPayment() {
         return SupportPayment.builder()
-                .memberPaymentMethodKey("PM-0001")
+                .paymentMethod(getPaymentMethodRequest())
+                .build();
+    }
+
+    private PaymentMethod getPaymentMethodRequest() {
+        return PaymentMethod.builder()
+                .paymentMethodKey("PM-0001")
                 .build();
     }
 
     private SupportDelivery getSupportDelivery() {
         return SupportDelivery.builder()
+                .support(getSupportRequest())
+                .deliveryAddress(getDeliveryAddressRequest())
+                .build();
+    }
+
+    private Support getSupportRequest() {
+        return Support.builder()
                 .supportKey("SS-0001")
-                .memberDeliveryAddressKey("DA-0001")
+                .build();
+    }
+
+    private DeliveryAddress getDeliveryAddressRequest() {
+        return DeliveryAddress.builder()
+                .deliveryAddressKey("DA-0001")
                 .build();
     }
 
@@ -84,7 +120,7 @@ public class SupportServiceTest {
         Support support = getSupport();
         SupportDelivery supportDelivery = getSupportDelivery();
 
-        given(supportPort.getSupportDeliveryBySupportKey(any()))
+        given(supportPort.getSupportDeliveryRequest(any()))
                 .willReturn(supportDelivery);
 
         given(supportPort.saveSupportDelivery(any(SupportDelivery.class)))
@@ -104,7 +140,7 @@ public class SupportServiceTest {
         Support support = getSupport();
         SupportDelivery supportDelivery = getSupportDelivery();
 
-        given(supportPort.getSupportDeliveryBySupportKey(any()))
+        given(supportPort.getSupportDeliveryRequest(any()))
                 .willReturn(supportDelivery);
 
         given(supportPort.saveSupportDelivery(any(SupportDelivery.class)))
@@ -124,7 +160,7 @@ public class SupportServiceTest {
         Support support = getSupport();
         SupportDelivery supportDelivery = getSupportDelivery();
 
-        given(supportPort.getSupportDeliveryBySupportKey(any()))
+        given(supportPort.getSupportDeliveryRequest(any()))
                 .willReturn(supportDelivery);
 
         given(supportPort.saveSupportDelivery(any(SupportDelivery.class)))


### PR DESCRIPTION
### 작업내역
- 도메인 모델에서 String으로 따로 선언했던 변수들을 객체로 변경
- Mapper에서 to객체로 변환하던 default 메소드를 공통 메소드로 분리

### 이슈
- 도메인 모델에서 String id, String key 등으로 하나씩 선언해주면 변수가 너무 많아진다.
- default 메소드로 분리한 이유는 여러 군데에서 동일한 메소드를 반복하여 사용하기 때문이다.