### PR TITLE
[#22] 로그인 기능 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -10,6 +10,8 @@
 
 include::{docdir}/member.adoc[]
 
+include::{docdir}/login.adoc[]
+
 include::{docdir}/funding.adoc[]
 
 include::{docdir}/support.adoc[]

--- a/src/main/java/com/flab/funding/application/ports/input/LoginUseCase.java
+++ b/src/main/java/com/flab/funding/application/ports/input/LoginUseCase.java
@@ -4,7 +4,5 @@ import com.flab.funding.domain.model.Member;
 
 public interface LoginUseCase {
 
-    Member getMemberByUserKey(String userKey);
-
     Member login(Member member);
 }

--- a/src/main/java/com/flab/funding/application/ports/input/RegisterMemberUseCase.java
+++ b/src/main/java/com/flab/funding/application/ports/input/RegisterMemberUseCase.java
@@ -5,4 +5,6 @@ import com.flab.funding.domain.model.Member;
 public interface RegisterMemberUseCase {
 
     Member registerMember(Member member);
+
+    Member getMemberByUserKey(String userKey);
 }

--- a/src/main/java/com/flab/funding/application/ports/output/MemberPort.java
+++ b/src/main/java/com/flab/funding/application/ports/output/MemberPort.java
@@ -10,6 +10,8 @@ public interface MemberPort {
 
     Member getMemberByUserKey(String userKey);
 
-    List<Member> getMemberByEmail(String email);
+    Member getMemberByEmail(String email);
+
+    List<Member> getMembersByEmail(String email);
 
 }

--- a/src/main/java/com/flab/funding/domain/exception/EmptyMemberException.java
+++ b/src/main/java/com/flab/funding/domain/exception/EmptyMemberException.java
@@ -3,6 +3,6 @@ package com.flab.funding.domain.exception;
 public class EmptyMemberException extends MemberException {
 
     public EmptyMemberException() {
-        super("404", "FUNDING_NOT_EXIST");
+        super("404", "MEMBER_NOT_EXIST");
     }
 }

--- a/src/main/java/com/flab/funding/domain/model/FundingReward.java
+++ b/src/main/java/com/flab/funding/domain/model/FundingReward.java
@@ -48,4 +48,9 @@ public class FundingReward {
                 .expectDate(this.expectDate)
                 .build();
     }
+
+    public FundingReward unmapping() {
+        this.fundingRewardItems = null;
+        return this;
+    }
 }

--- a/src/main/java/com/flab/funding/domain/model/Support.java
+++ b/src/main/java/com/flab/funding/domain/model/Support.java
@@ -36,6 +36,22 @@ public class Support {
 
     public Support with(Member member,
                         Funding funding,
+                        FundingReward reward) {
+
+        return Support.builder()
+                .id(this.id)
+                .member(member)
+                .funding(funding)
+                .reward(reward)
+                .supportKey(this.supportKey)
+                .status(this.status)
+                .supportDelivery(this.supportDelivery)
+                .supportPayment(this.supportPayment)
+                .build();
+    }
+
+    public Support with(Member member,
+                        Funding funding,
                         SupportDelivery supportDelivery,
                         SupportPayment supportPayment) {
 
@@ -44,6 +60,24 @@ public class Support {
                 .member(member)
                 .funding(funding)
                 .reward(this.reward)
+                .supportKey(this.supportKey)
+                .status(this.status)
+                .supportDelivery(supportDelivery)
+                .supportPayment(supportPayment)
+                .build();
+    }
+
+    public Support with(Member member,
+                        Funding funding,
+                        FundingReward reward,
+                        SupportDelivery supportDelivery,
+                        SupportPayment supportPayment) {
+
+        return Support.builder()
+                .id(this.id)
+                .member(member)
+                .funding(funding)
+                .reward(reward)
                 .supportKey(this.supportKey)
                 .status(this.status)
                 .supportDelivery(supportDelivery)

--- a/src/main/java/com/flab/funding/domain/model/SupportDelivery.java
+++ b/src/main/java/com/flab/funding/domain/model/SupportDelivery.java
@@ -57,6 +57,21 @@ public class SupportDelivery {
                 .build();
     }
 
+    public SupportDelivery with(Support support,
+                                MemberDeliveryAddress memberDeliveryAddress) {
+
+        return SupportDelivery.builder()
+                .id(this.id)
+                .support(support)
+                .memberDeliveryAddress(memberDeliveryAddress)
+                .status(this.status)
+                .shipmentName(this.shipmentName)
+                .shipmentAt(this.shipmentAt)
+                .trackingName(this.trackingName)
+                .trackingAt(this.trackingAt)
+                .build();
+    }
+
     public SupportDelivery shippedOut() {
         this.status = SupportDeliveryStatus.SHIPPED;
         return this;

--- a/src/main/java/com/flab/funding/domain/model/SupportPayment.java
+++ b/src/main/java/com/flab/funding/domain/model/SupportPayment.java
@@ -50,4 +50,17 @@ public class SupportPayment {
                 .build();
     }
 
+    public SupportPayment with(Support support,
+                               MemberPaymentMethod memberPaymentMethod) {
+
+        return SupportPayment.builder()
+                .id(this.id)
+                .support(support)
+                .memberPaymentMethod(memberPaymentMethod)
+                .status(this.status)
+                .amount(this.amount)
+                .paymentAt(this.paymentAt)
+                .build();
+    }
+
 }

--- a/src/main/java/com/flab/funding/domain/service/MemberService.java
+++ b/src/main/java/com/flab/funding/domain/service/MemberService.java
@@ -54,7 +54,7 @@ public class MemberService implements RegisterMemberUseCase, DeregisterMemberUse
 
         if (member.getPassword().equals(findMember.getPassword())) {
 
-            return member;
+            return findMember;
         }
 
         throw new EmptyMemberException();

--- a/src/main/java/com/flab/funding/domain/service/MemberService.java
+++ b/src/main/java/com/flab/funding/domain/service/MemberService.java
@@ -5,6 +5,7 @@ import com.flab.funding.application.ports.input.LoginUseCase;
 import com.flab.funding.application.ports.input.RegisterMemberUseCase;
 import com.flab.funding.application.ports.output.MemberPort;
 import com.flab.funding.domain.exception.DuplicateMemberException;
+import com.flab.funding.domain.exception.EmptyMemberException;
 import com.flab.funding.domain.model.Member;
 import com.flab.funding.infrastructure.config.UseCase;
 import lombok.RequiredArgsConstructor;
@@ -41,9 +42,23 @@ public class MemberService implements RegisterMemberUseCase, DeregisterMemberUse
         return memberPort.getMemberByUserKey(userKey);
     }
 
-    // TODO : Login 기능 구현
     @Override
     public Member login(Member member) {
-        return null;
+
+        List<Member> findMembers = memberPort.getMemberByEmail(member.getEmail());
+
+        if (findMembers.isEmpty()) {
+            throw new EmptyMemberException();
+        }
+
+        for (Member findMember : findMembers) {
+
+            if (member.getPassword().equals(findMember.getPassword())) {
+
+                return member;
+            }
+        }
+
+        throw new EmptyMemberException();
     }
 }

--- a/src/main/java/com/flab/funding/domain/service/MemberService.java
+++ b/src/main/java/com/flab/funding/domain/service/MemberService.java
@@ -25,7 +25,7 @@ public class MemberService implements RegisterMemberUseCase, DeregisterMemberUse
     }
 
     private void validateDuplicateMember(Member member) {
-        List<Member> findMembers = memberPort.getMemberByEmail(member.getEmail());
+        List<Member> findMembers = memberPort.getMembersByEmail(member.getEmail());
         if(!findMembers.isEmpty()) {
             throw new DuplicateMemberException();
         }
@@ -45,18 +45,16 @@ public class MemberService implements RegisterMemberUseCase, DeregisterMemberUse
     @Override
     public Member login(Member member) {
 
-        List<Member> findMembers = memberPort.getMemberByEmail(member.getEmail());
+        Member findMember = memberPort.getMemberByEmail(member.getEmail());
 
-        if (findMembers.isEmpty()) {
+        if (findMember.getId() == null) {
+
             throw new EmptyMemberException();
         }
 
-        for (Member findMember : findMembers) {
+        if (member.getPassword().equals(findMember.getPassword())) {
 
-            if (member.getPassword().equals(findMember.getPassword())) {
-
-                return member;
-            }
+            return member;
         }
 
         throw new EmptyMemberException();

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/data/request/LoginRequest.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/data/request/LoginRequest.java
@@ -1,0 +1,23 @@
+package com.flab.funding.infrastructure.adapters.input.data.request;
+
+import com.flab.funding.domain.model.Member;
+import com.flab.funding.infrastructure.adapters.input.mapper.MemberMapper;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class LoginRequest {
+
+    private String email;
+    private String password;
+
+    public Member toMember() {
+
+        return MemberMapper.INSTANCE.toMember(this);
+    }
+}

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/data/request/LoginRequest.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/data/request/LoginRequest.java
@@ -2,6 +2,8 @@ package com.flab.funding.infrastructure.adapters.input.data.request;
 
 import com.flab.funding.domain.model.Member;
 import com.flab.funding.infrastructure.adapters.input.mapper.MemberMapper;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +15,10 @@ import lombok.NoArgsConstructor;
 @Getter
 public class LoginRequest {
 
+    @NotEmpty
+    @Email
     private String email;
+
     private String password;
 
     public Member toMember() {

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/data/response/LoginResponse.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/data/response/LoginResponse.java
@@ -1,0 +1,21 @@
+package com.flab.funding.infrastructure.adapters.input.data.response;
+
+import com.flab.funding.domain.model.Member;
+import com.flab.funding.domain.model.MemberStatus;
+import com.flab.funding.infrastructure.adapters.input.mapper.MemberMapper;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class LoginResponse {
+
+    private String userKey;
+
+    private MemberStatus status;
+
+    public static LoginResponse from(Member member) {
+
+        return MemberMapper.INSTANCE.toLoginResponse(member);
+    }
+}

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/MemberMapper.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/MemberMapper.java
@@ -4,6 +4,7 @@ import com.flab.funding.domain.model.Member;
 import com.flab.funding.infrastructure.adapters.input.data.request.LoginRequest;
 import com.flab.funding.infrastructure.adapters.input.data.request.MemberInfoRequest;
 import com.flab.funding.infrastructure.adapters.input.data.request.MemberRegisterRequest;
+import com.flab.funding.infrastructure.adapters.input.data.response.LoginResponse;
 import com.flab.funding.infrastructure.adapters.input.data.response.MemberInfoResponse;
 import com.flab.funding.infrastructure.adapters.input.data.response.MemberRegisterResponse;
 import org.mapstruct.Mapper;
@@ -24,4 +25,6 @@ public interface MemberMapper {
     MemberInfoResponse toMemberInfoResponse(Member member);
 
     Member toMember(LoginRequest loginRequest);
+
+    LoginResponse toLoginResponse(Member member);
 }

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/MemberMapper.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/mapper/MemberMapper.java
@@ -1,6 +1,7 @@
 package com.flab.funding.infrastructure.adapters.input.mapper;
 
 import com.flab.funding.domain.model.Member;
+import com.flab.funding.infrastructure.adapters.input.data.request.LoginRequest;
 import com.flab.funding.infrastructure.adapters.input.data.request.MemberInfoRequest;
 import com.flab.funding.infrastructure.adapters.input.data.request.MemberRegisterRequest;
 import com.flab.funding.infrastructure.adapters.input.data.response.MemberInfoResponse;
@@ -21,4 +22,6 @@ public interface MemberMapper {
     Member toMember(MemberInfoRequest memberInfoRequest);
 
     MemberInfoResponse toMemberInfoResponse(Member member);
+
+    Member toMember(LoginRequest loginRequest);
 }

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/rest/LoginRestAdapter.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/rest/LoginRestAdapter.java
@@ -1,0 +1,26 @@
+package com.flab.funding.infrastructure.adapters.input.rest;
+
+import com.flab.funding.application.ports.input.LoginUseCase;
+import com.flab.funding.domain.model.Member;
+import com.flab.funding.infrastructure.adapters.input.data.request.LoginRequest;
+import com.flab.funding.infrastructure.adapters.input.data.response.LoginResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LoginRestAdapter {
+
+    private final LoginUseCase loginUseCase;
+
+    @PostMapping("/members/authentication")
+    @ResponseBody
+    public LoginResponse login(@RequestBody @Valid LoginRequest request) {
+        Member member = loginUseCase.login(request.toMember());
+        return LoginResponse.from(member);
+    }
+}

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/rest/LoginRestAdapter.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/rest/LoginRestAdapter.java
@@ -17,7 +17,7 @@ public class LoginRestAdapter {
 
     private final LoginUseCase loginUseCase;
 
-    @PostMapping("/members/authentication")
+    @PostMapping("/accounts/authentication")
     @ResponseBody
     public LoginResponse login(@RequestBody @Valid LoginRequest request) {
         Member member = loginUseCase.login(request.toMember());

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/rest/MemberDeliveryAddressRestAdapter.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/rest/MemberDeliveryAddressRestAdapter.java
@@ -16,7 +16,7 @@ public class MemberDeliveryAddressRestAdapter {
 
     private final RegisterDeliveryAddressUseCase registerDeliveryAddressUseCase;
 
-    @PostMapping("/deliveryAddresses")
+    @PostMapping("/members/deliveryAddresses")
     @ResponseBody
     public MemberDeliveryAddressRegisterResponse registerMemberDeliveryAddress(@RequestBody MemberDeliveryAddressRegisterRequest request) {
         MemberDeliveryAddress memberDeliveryAddress = registerDeliveryAddressUseCase.registerDeliveryAddress(request.toDeliveryAddress());

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/rest/MemberPaymentMethodRestAdapter.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/rest/MemberPaymentMethodRestAdapter.java
@@ -16,7 +16,7 @@ public class MemberPaymentMethodRestAdapter {
 
     private final RegisterPaymentMethodUseCase registerPaymentMethodUseCase;
 
-    @PostMapping("/paymentMethods")
+    @PostMapping("/members/paymentMethods")
     @ResponseBody
     public MemberPaymentMethodRegisterResponse registerMemberPaymentMethod(@RequestBody MemberPaymentMethodRegisterRequest request) {
         MemberPaymentMethod memberPaymentMethod = registerPaymentMethodUseCase.registerPaymentMethod(request.toPaymentMethod());

--- a/src/main/java/com/flab/funding/infrastructure/adapters/input/rest/MemberRestAdapter.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/input/rest/MemberRestAdapter.java
@@ -1,7 +1,6 @@
 package com.flab.funding.infrastructure.adapters.input.rest;
 
 import com.flab.funding.application.ports.input.DeregisterMemberUseCase;
-import com.flab.funding.application.ports.input.LoginUseCase;
 import com.flab.funding.application.ports.input.RegisterMemberUseCase;
 import com.flab.funding.domain.model.Member;
 import com.flab.funding.infrastructure.adapters.input.data.request.MemberRegisterRequest;
@@ -17,7 +16,6 @@ public class MemberRestAdapter {
 
     private final RegisterMemberUseCase registerMemberUseCase;
     private final DeregisterMemberUseCase deregisterMemberUseCase;
-    private final LoginUseCase loginUseCase;
 
     @PostMapping("/members")
     @ResponseBody
@@ -36,7 +34,7 @@ public class MemberRestAdapter {
     @GetMapping("/members/{userKey}")
     @ResponseBody
     public MemberInfoResponse getMember(@PathVariable("userKey") String userKey) {
-        Member member = loginUseCase.getMemberByUserKey(userKey);
+        Member member = registerMemberUseCase.getMemberByUserKey(userKey);
         return MemberInfoResponse.from(member);
     }
 }

--- a/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/MemberPersistenceAdapter.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/MemberPersistenceAdapter.java
@@ -33,8 +33,14 @@ public class MemberPersistenceAdapter implements MemberPort {
     }
 
     @Override
-    public List<Member> getMemberByEmail(String email) {
-        List<MemberEntity> findMembers = memberRepository.findByEmail(email);
+    public Member getMemberByEmail(String email) {
+        MemberEntity findMemberEntity = memberRepository.findByEmail(email).orElse(MemberEntity.builder().build());
+        return findMemberEntity.toMember();
+    }
+
+    @Override
+    public List<Member> getMembersByEmail(String email) {
+        List<MemberEntity> findMembers = memberRepository.findAllByEmail(email);
         return findMembers.stream().map(MemberEntity::toMember).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/repository/MemberRepository.java
+++ b/src/main/java/com/flab/funding/infrastructure/adapters/output/persistence/repository/MemberRepository.java
@@ -10,5 +10,7 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
     Optional<MemberEntity> findByUserKey(String userKey);
 
-    List<MemberEntity> findByEmail(String email);
+    Optional<MemberEntity> findByEmail(String email);
+
+    List<MemberEntity> findAllByEmail(String email);
 }

--- a/src/test/java/com/flab/funding/data/FundingTestData.java
+++ b/src/test/java/com/flab/funding/data/FundingTestData.java
@@ -151,20 +151,6 @@ public class FundingTestData {
                 .build();
     }
 
-    public static FundingReward getRealFundingReward() {
-        return FundingReward.builder()
-                .id(1L)
-                .funding(getFundingRequest())
-                .isDelivery(true)
-                .rewardTitle("귀걸이 세트")
-                .amount(BigInteger.valueOf(15000))
-                .fundingRewardItems(getFundingRewardItems())
-                .countLimit(10)
-                .personalLimit(5)
-                .expectDate(LocalDate.of(2024, 3, 31))
-                .build();
-    }
-
     public static FundingRewardItem getFundingRewardItem(Funding savedFunding,
                                                          FundingReward savedFundingReward,
                                                          FundingItem savedFundingItem) {

--- a/src/test/java/com/flab/funding/data/MemberTestData.java
+++ b/src/test/java/com/flab/funding/data/MemberTestData.java
@@ -37,6 +37,7 @@ public class MemberTestData {
                 .gender(MemberGender.FEMALE)
                 .birthday(LocalDate.of(1998, 1, 30))
                 .password("")
+                .status(MemberStatus.ACTIVATE)
                 .build();
     }
 

--- a/src/test/java/com/flab/funding/data/SupportTestData.java
+++ b/src/test/java/com/flab/funding/data/SupportTestData.java
@@ -1,8 +1,6 @@
 package com.flab.funding.data;
 
-import com.flab.funding.domain.model.Support;
-import com.flab.funding.domain.model.SupportDelivery;
-import com.flab.funding.domain.model.SupportPayment;
+import com.flab.funding.domain.model.*;
 
 import static com.flab.funding.data.FundingTestData.getFundingRequest;
 import static com.flab.funding.data.FundingTestData.getRewardRequest;
@@ -26,16 +24,17 @@ public class SupportTestData {
                 .build();
     }
 
-    private static SupportPayment getSupportPayment() {
+    public static SupportPayment getSupportPayment() {
         return SupportPayment.builder()
                 .memberPaymentMethod(getPaymentMethodRequest())
+                .status(SupportPaymentStatus.READY)
                 .build();
     }
 
     public static SupportDelivery getSupportDelivery() {
         return SupportDelivery.builder()
-                .support(getSupportRequest())
                 .memberDeliveryAddress(getDeliveryAddressRequest())
+                .status(SupportDeliveryStatus.READY)
                 .build();
     }
 }

--- a/src/test/java/com/flab/funding/repository/FundingPersistenceAdapterTest.java
+++ b/src/test/java/com/flab/funding/repository/FundingPersistenceAdapterTest.java
@@ -151,7 +151,7 @@ public class FundingPersistenceAdapterTest {
         Funding funding = getFunding().with(member).register();
         Funding savedFunding = fundingPort.saveFunding(funding);
 
-        FundingReward fundingReward = getFundingReward().with(savedFunding);
+        FundingReward fundingReward = getFundingReward().with(savedFunding).unmapping();
         
         //when
         FundingReward savedFundingReward = fundingPort.saveFundingReward(fundingReward);
@@ -242,7 +242,7 @@ public class FundingPersistenceAdapterTest {
         Funding funding = getFunding().with(member).register();
         Funding savedFunding = fundingPort.saveFunding(funding);
 
-        FundingReward fundingReward = getFundingReward().with(savedFunding);
+        FundingReward fundingReward = getFundingReward().with(savedFunding).unmapping();
         FundingReward savedFundingReward = fundingPort.saveFundingReward(fundingReward);
 
         //when

--- a/src/test/java/com/flab/funding/repository/MemberPersistenceAdapterTest.java
+++ b/src/test/java/com/flab/funding/repository/MemberPersistenceAdapterTest.java
@@ -77,7 +77,7 @@ public class MemberPersistenceAdapterTest {
         Member savedMember = memberPort.saveMember(member);
 
         // when
-        List<Member> findMember = memberPort.getMemberByEmail(savedMember.getEmail());
+        List<Member> findMember = memberPort.getMembersByEmail(savedMember.getEmail());
 
         //then
         assertNotNull(savedMember.getUserKey());

--- a/src/test/java/com/flab/funding/rest/LoginRestAdapterTest.java
+++ b/src/test/java/com/flab/funding/rest/LoginRestAdapterTest.java
@@ -1,0 +1,78 @@
+package com.flab.funding.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.funding.domain.model.Member;
+import com.flab.funding.domain.model.MemberStatus;
+import com.flab.funding.domain.service.MemberService;
+import com.flab.funding.infrastructure.adapters.input.data.request.LoginRequest;
+import com.flab.funding.infrastructure.adapters.input.rest.MemberRestAdapter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+@WebMvcTest(MemberRestAdapter.class)
+@AutoConfigureRestDocs
+public class LoginRestAdapterTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("로그인")
+    public void login() throws Exception {
+
+        //given
+        LoginRequest request = LoginRequest.builder()
+                .email("Test@gamil.com")
+                .password("1234")
+                .build();
+
+        Member response = Member.builder()
+                .userKey("MM-0001")
+                .status(MemberStatus.ACTIVATE)
+                .build();
+
+        given(memberService.login(any(request.toMember().getClass())))
+                .willReturn(response);
+
+        //when
+        //then
+        this.mockMvc.perform(post("/members/authorization")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("{class-name}/{method-name}",
+                        requestFields(
+                                fieldWithPath("email").description("이메일"),
+                                fieldWithPath("password").description("비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("userKey").description("회원번호(외부용)"),
+                                fieldWithPath("status").description("회원상태")
+                        )));
+
+    }
+}

--- a/src/test/java/com/flab/funding/rest/LoginRestAdapterTest.java
+++ b/src/test/java/com/flab/funding/rest/LoginRestAdapterTest.java
@@ -5,7 +5,7 @@ import com.flab.funding.domain.model.Member;
 import com.flab.funding.domain.model.MemberStatus;
 import com.flab.funding.domain.service.MemberService;
 import com.flab.funding.infrastructure.adapters.input.data.request.LoginRequest;
-import com.flab.funding.infrastructure.adapters.input.rest.MemberRestAdapter;
+import com.flab.funding.infrastructure.adapters.input.rest.LoginRestAdapter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
-@WebMvcTest(MemberRestAdapter.class)
+@WebMvcTest(LoginRestAdapter.class)
 @AutoConfigureRestDocs
 public class LoginRestAdapterTest {
 
@@ -59,7 +59,7 @@ public class LoginRestAdapterTest {
 
         //when
         //then
-        this.mockMvc.perform(post("/members/authentication")
+        this.mockMvc.perform(post("/accounts/authentication")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/flab/funding/rest/LoginRestAdapterTest.java
+++ b/src/test/java/com/flab/funding/rest/LoginRestAdapterTest.java
@@ -59,7 +59,7 @@ public class LoginRestAdapterTest {
 
         //when
         //then
-        this.mockMvc.perform(post("/members/authorization")
+        this.mockMvc.perform(post("/members/authentication")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/flab/funding/rest/MemberDeliveryAddressRestAdapterTest.java
+++ b/src/test/java/com/flab/funding/rest/MemberDeliveryAddressRestAdapterTest.java
@@ -73,7 +73,7 @@ public class MemberDeliveryAddressRestAdapterTest {
 
         //when
         //then
-        this.mockMvc.perform(post("/deliveryAddresses")
+        this.mockMvc.perform(post("/members/deliveryAddresses")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/flab/funding/rest/MemberPaymentMethodRestAdapterTest.java
+++ b/src/test/java/com/flab/funding/rest/MemberPaymentMethodRestAdapterTest.java
@@ -65,7 +65,7 @@ public class MemberPaymentMethodRestAdapterTest {
         //when
 
         //then
-        this.mockMvc.perform(post("/paymentMethods")
+        this.mockMvc.perform(post("/members/paymentMethods")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/flab/funding/service/MemberServiceTest.java
+++ b/src/test/java/com/flab/funding/service/MemberServiceTest.java
@@ -91,7 +91,7 @@ public class MemberServiceTest {
         //given
         Member member = getMember();
 
-        given(memberPort.getMemberByEmail(member.getEmail()))
+        given(memberPort.getMemberByEmail(any(String.class)))
                 .willReturn(getRealMember());
 
         //when
@@ -113,7 +113,7 @@ public class MemberServiceTest {
 
         Member member = getMember();
 
-        given(memberPort.getMemberByEmail(member.getEmail()))
+        given(memberPort.getMemberByEmail(any(String.class)))
                 .willReturn(member);
 
         //when
@@ -132,8 +132,8 @@ public class MemberServiceTest {
 
         Member member = getMember();
 
-        given(memberPort.getMembersByEmail(member.getEmail()))
-                .willReturn(List.of(member));
+        given(memberPort.getMemberByEmail(any(String.class)))
+                .willReturn(getRealMember());
 
         //when
         assertThrows(EmptyMemberException.class, () -> memberService.login(request));

--- a/src/test/java/com/flab/funding/service/MemberServiceTest.java
+++ b/src/test/java/com/flab/funding/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.flab.funding.service;
 
 import com.flab.funding.application.ports.output.MemberPort;
 import com.flab.funding.domain.exception.DuplicateMemberException;
+import com.flab.funding.domain.exception.EmptyMemberException;
 import com.flab.funding.domain.model.Member;
 import com.flab.funding.domain.model.MemberStatus;
 import com.flab.funding.domain.service.MemberService;
@@ -81,5 +82,59 @@ public class MemberServiceTest {
         //then
         assertEquals(MemberStatus.WITHDRAW, deregistMember.getStatus());
 
+    }
+
+    @Test
+    @DisplayName("로그인")
+    public void login() {
+        //given
+        Member member = getMember();
+
+        given(memberPort.getMemberByEmail(member.getEmail()))
+                .willReturn(List.of(member));
+
+        //when
+        Member loginMember = memberService.login(member);
+
+        //then
+        assertNotNull(loginMember.getUserKey());
+        assertEquals(MemberStatus.ACTIVATE, loginMember.getStatus());
+    }
+
+    @Test
+    @DisplayName("잘못된 이메일로 로그인")
+    public void loginByInvalidUser() throws Exception {
+        //given
+        Member request = Member.builder()
+                .email("invalid@gmail.com")
+                .password("1234")
+                .build();
+
+        Member member = getMember();
+
+        given(memberPort.getMemberByEmail(member.getEmail()))
+                .willReturn(List.of(member));
+
+        //when
+        //then
+        assertThrows(EmptyMemberException.class, () -> memberService.login(request));
+    }
+
+    @Test
+    @DisplayName("잘못된 패스워드로 로그인")
+    public void loginByInvalidPassword() throws Exception {
+        //given
+        Member request = Member.builder()
+                .email("Test@gmail.com")
+                .password("1234")
+                .build();
+
+        Member member = getMember();
+
+        given(memberPort.getMemberByEmail(member.getEmail()))
+                .willReturn(List.of(member));
+
+        //when
+        assertThrows(EmptyMemberException.class, () -> memberService.login(request));
     }
 }

--- a/src/test/java/com/flab/funding/service/MemberServiceTest.java
+++ b/src/test/java/com/flab/funding/service/MemberServiceTest.java
@@ -111,7 +111,7 @@ public class MemberServiceTest {
                 .password("1234")
                 .build();
 
-        Member member = getMember();
+        Member member = getRealMember();
 
         given(memberPort.getMemberByEmail(any(String.class)))
                 .willReturn(member);
@@ -130,10 +130,10 @@ public class MemberServiceTest {
                 .password("1234")
                 .build();
 
-        Member member = getMember();
+        Member member = getRealMember();
 
         given(memberPort.getMemberByEmail(any(String.class)))
-                .willReturn(getRealMember());
+                .willReturn(member);
 
         //when
         assertThrows(EmptyMemberException.class, () -> memberService.login(request));

--- a/src/test/java/com/flab/funding/service/MemberServiceTest.java
+++ b/src/test/java/com/flab/funding/service/MemberServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static com.flab.funding.data.MemberTestData.getMember;
+import static com.flab.funding.data.MemberTestData.getRealMember;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -38,7 +39,7 @@ public class MemberServiceTest {
         given(memberPort.saveMember(any(Member.class)))
                 .willAnswer(invocation -> invocation.getArguments()[0]);
 
-        given(memberPort.getMemberByEmail(member.getEmail()))
+        given(memberPort.getMembersByEmail(member.getEmail()))
                 .willReturn(List.of());
 
         //when
@@ -56,7 +57,7 @@ public class MemberServiceTest {
         //given
         Member member = getMember();
 
-        given(memberPort.getMemberByEmail(member.getEmail()))
+        given(memberPort.getMembersByEmail(member.getEmail()))
                 .willReturn(List.of(member));
         
         //when
@@ -91,7 +92,7 @@ public class MemberServiceTest {
         Member member = getMember();
 
         given(memberPort.getMemberByEmail(member.getEmail()))
-                .willReturn(List.of(member));
+                .willReturn(getRealMember());
 
         //when
         Member loginMember = memberService.login(member);
@@ -103,7 +104,7 @@ public class MemberServiceTest {
 
     @Test
     @DisplayName("잘못된 이메일로 로그인")
-    public void loginByInvalidUser() throws Exception {
+    public void loginByInvalidUser() {
         //given
         Member request = Member.builder()
                 .email("invalid@gmail.com")
@@ -113,7 +114,7 @@ public class MemberServiceTest {
         Member member = getMember();
 
         given(memberPort.getMemberByEmail(member.getEmail()))
-                .willReturn(List.of(member));
+                .willReturn(member);
 
         //when
         //then
@@ -122,7 +123,7 @@ public class MemberServiceTest {
 
     @Test
     @DisplayName("잘못된 패스워드로 로그인")
-    public void loginByInvalidPassword() throws Exception {
+    public void loginByInvalidPassword() {
         //given
         Member request = Member.builder()
                 .email("Test@gmail.com")
@@ -131,7 +132,7 @@ public class MemberServiceTest {
 
         Member member = getMember();
 
-        given(memberPort.getMemberByEmail(member.getEmail()))
+        given(memberPort.getMembersByEmail(member.getEmail()))
                 .willReturn(List.of(member));
 
         //when

--- a/src/test/java/com/flab/funding/service/SupportServiceTest.java
+++ b/src/test/java/com/flab/funding/service/SupportServiceTest.java
@@ -112,7 +112,7 @@ public class SupportServiceTest {
     public void shippedOut() {
         //given
         Support support = getSupport();
-        SupportDelivery supportDelivery = getSupportDelivery();
+        SupportDelivery supportDelivery = getSupportDelivery().with(support);
 
         given(supportPort.getSupportDeliveryBySupportKey(any()))
                 .willReturn(supportDelivery);
@@ -132,7 +132,7 @@ public class SupportServiceTest {
     public void outForDelivery() {
         //given
         Support support = getSupport();
-        SupportDelivery supportDelivery = getSupportDelivery();
+        SupportDelivery supportDelivery = getSupportDelivery().with(support);;
 
         given(supportPort.getSupportDeliveryBySupportKey(any()))
                 .willReturn(supportDelivery);
@@ -152,7 +152,7 @@ public class SupportServiceTest {
     public void deliveryComplete() {
         //given
         Support support = getSupport();
-        SupportDelivery supportDelivery = getSupportDelivery();
+        SupportDelivery supportDelivery = getSupportDelivery().with(support);;
 
         given(supportPort.getSupportDeliveryBySupportKey(any()))
                 .willReturn(supportDelivery);


### PR DESCRIPTION
### 작업내역

- REST 규칙에 맞게 기존 API 수정 (회원 배송지, 결제수단)
- 공통으로 뺀 테스트 데이터 오류 수정
- 로그인 API 추가
- 로그인 API 문서 추가

### 이슈

- 원래 로그인 URI를 "/members/auth~"로 하려고 했으나 "members/{userKey}"가 존재하기 때문에,
- HttpRequestMethodNotSupportedException 오류가 발생해 "/accounts/auth"로 변경했다.
- 비밀번호 암호화 적용 후 API 수정 필요